### PR TITLE
Colossalg - Fix issue with Message::withBody and implement deep copy for Message

### DIFF
--- a/src/Http/Message.php
+++ b/src/Http/Message.php
@@ -2,27 +2,9 @@
 
 namespace Colossal\Http;
 
+use \Colossal\Utilities\Utilities;
 use \Psr\Http\Message\MessageInterface;
 use \Psr\Http\Message\StreamInterface;
-use \UnexpectedValueException;
-
-function isStringOrArrayOfStrings(mixed $value): bool
-{
-    if (is_string($value)) {
-        return true;
-    }
-
-    if (is_array($value)) {
-        foreach ($value as $val) {
-            if (!is_string($val)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    return false;
-}
 
 class Message implements MessageInterface
 {
@@ -41,6 +23,15 @@ class Message implements MessageInterface
         $this->protocolVersion  = self::DEFAULT_PROTOCOL_VERSION;
         $this->headers          = [];
         $this->body             = new NullStream;
+    }
+
+    /**
+     * Copy constructor.
+     */
+    public function __clone()
+    {
+        $this->headers  = Utilities::arrayClone($this->headers);
+        $this->body     = clone $this->body;
     }
 
     /**
@@ -129,7 +120,7 @@ class Message implements MessageInterface
         if (!is_string($name)) {
             throw new \InvalidArgumentException("Argument 'name' must have type string.");
         }
-        if (!isStringOrArrayOfStrings($value)) {
+        if (!Utilities::isStringOrArrayOfStrings($value)) {
             throw new \InvalidArgumentException("Argument 'value' must have type string or string[].");
         }
 
@@ -151,7 +142,7 @@ class Message implements MessageInterface
         if (!is_string($name)) {
             throw new \InvalidArgumentException("Argument 'name' must have type string.");
         }
-        if (!isStringOrArrayOfStrings($value)) {
+        if (!Utilities::isStringOrArrayOfStrings($value)) {
             throw new \InvalidArgumentException("Argument 'value' must have type string or string[].");
         }
 
@@ -195,10 +186,12 @@ class Message implements MessageInterface
     /**
      * @see MessageInterface::withBody()
      */
-    public function withBody(StreamInterface $body)
+    public function withBody(StreamInterface $body): Message
     {
         $newMessage = clone $this;
         $newMessage->body = $body;
+
+        return $newMessage;
     }
 
     /**

--- a/src/Utilities/Utilities.php
+++ b/src/Utilities/Utilities.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace Colossal\Utilities;
+
+class Utilities
+{
+    /**
+     * This function performs a deep copy of a given array.
+     * 
+     * Curtesy of Andre Larsson from this Stack Overflow thread:
+     * https://stackoverflow.com/questions/1532618/is-there-a-function-to-make-a-copy-of-a-php-array-to-another
+     * 
+     * @param array $array The array to copy.
+     * @return array A copy of the array.
+     */
+    static function arrayClone(array $array): array
+    {
+        return array_map(function($element) {
+            return ((is_array($element))
+                ? self::arrayClone($element)
+                : ((is_object($element))
+                    ? clone $element
+                    : $element
+                )
+            );
+        }, $array);
+    }
+
+    /**
+     * This function checks whether $value a string or an array of strings.
+     * @param mixed $value The value to check.
+     * @return bool Whether $value is a string or an array of strings.
+     */
+    static function isStringOrArrayOfStrings(mixed $value): bool
+    {
+        if (is_string($value)) {
+            return true;
+        }
+
+        if (is_array($value)) {
+            foreach ($value as $val) {
+                if (!is_string($val)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/test/MessageTest.php
+++ b/test/MessageTest.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 
 use Colossal\Http\Message;
+use Colossal\Http\NullStream;
 use PHPUnit\Framework\TestCase;
 
 final class MessageTest extends TestCase
@@ -130,5 +131,12 @@ final class MessageTest extends TestCase
         // Test that the method will throw an exception if the argument 'name' is not a string
         $this->expectException(\InvalidArgumentException::class);
         $this->message->withoutHeader(1);
+    }
+
+    public function testWithBody(): void
+    {
+        // Test the general operation of the method
+        $newMessage = $this->message->withBody(new NullStream);
+        $this->assertFalse($this->message->getBody() === $newMessage->getBody());
     }
 }


### PR DESCRIPTION
This PR fixes an issue with Message::withBody where I was not returning the modified message containing the new body stream.

I also went ahead and implemented deep copying for Message to ensure we are not sharing state between instances once we have cloned them.