### PR TITLE
Colossalg - Remove code coverage ignore tags for Rfc3986 encoding methods

### DIFF
--- a/src/Http/NullStream.php
+++ b/src/Http/NullStream.php
@@ -55,7 +55,7 @@ class NullStream implements StreamInterface
      */
     public function eof(): bool
     {
-        return true;
+        throw new \RuntimeException(__METHOD__ . " operation is not supported.");
     }
 
     /**

--- a/src/Utilities/Rfc3986.php
+++ b/src/Utilities/Rfc3986.php
@@ -70,8 +70,6 @@ class Rfc3986
      * @throws \InvalidArgumentException If:
      *      - Any non US-ASCII characters are found within $userInfo.
      *      - Any invalid percent encoded characters are found within $userInfo.
-     *
-     * @codeCoverageIgnore - Covered by tests for encode.
      */
     public static function encodeUserInfo(string $userInfo): string
     {
@@ -94,8 +92,6 @@ class Rfc3986
      * @throws \InvalidArgumentException If:
      *      - Any non US-ASCII characters are found within $host.
      *      - Any invalid percent encoded characters are found within $host.
-     *
-     * @codeCoverageIgnore - Covered by tests for encode and isIPLiteral.
      */
     public static function encodeHost(string $host): string
     {
@@ -122,8 +118,6 @@ class Rfc3986
      * @throws \InvalidArgumentException If:
      *      - Any non US-ASCII characters are found within $path.
      *      - Any invalid percent encoded characters are found within $path.
-     *
-     * @codeCoverageIgnore - Covered by tests for encode.
      */
     public static function encodePath(string $path): string
     {
@@ -146,8 +140,6 @@ class Rfc3986
      * @throws \InvalidArgumentException If:
      *      - Any non US-ASCII characters are found within $query.
      *      - Any invalid percent encoded characters are found within $query.
-     *
-     * @codeCoverageIgnore - Covered by tests for encode.
      */
     public static function encodeQuery(string $query): string
     {
@@ -170,8 +162,6 @@ class Rfc3986
      * @throws \InvalidArgumentException If:
      *      - Any non US-ASCII characters are found within $fragment.
      *      - Any invalid percent encoded characters are found within $fragment.
-     *
-     * @codeCoverageIgnore - Covered by tests for encode.
      */
     public static function encodeFragment(string $fragment): string
     {

--- a/test/Utilities/Rfc3986Test.php
+++ b/test/Utilities/Rfc3986Test.php
@@ -33,6 +33,41 @@ final class Rfc3986Test extends TestCase
         Rfc3986::encodeScheme("1");
     }
 
+    public function testEncodeUserInfo(): void
+    {
+        // Test that the method correctly encodes each character from the unreserved set, sub delims and gen delims
+        $this->assertEquals("aAzZ09!$&'()*+,;=:%2F%3F%23%5B%5D%40", Rfc3986::encodeUserInfo("aAzZ09!$&'()*+,;=:/?#[]@"));
+    }
+
+    public function testEncodeHost(): void
+    {
+        // Test that the method correctly encodes each character from the unreserved set, sub delims and gen delims
+        // (String should also be converted to lower case)
+        $this->assertEquals("aazz09!$&'()*+,;=%3A%2F%3F%23%5B%5D%40", Rfc3986::encodeHost("aAzZ09!$&'()*+,;=:/?#[]@"));
+
+        // Test that we do not perform encoding for IPv6 or IPVFuture addresses
+        $this->assertEquals("[1:2:3:4:5:6:7:8]", Rfc3986::encodeHost("[1:2:3:4:5:6:7:8]"));
+        $this->assertEquals("[v7.1:2:3:4]", Rfc3986::encodeHost("[v7.1:2:3:4]"));
+    }
+
+    public function testEncodePath(): void
+    {
+        // Test that the method correctly encodes each character from the unreserved set, sub delims and gen delims
+        $this->assertEquals("aAzZ09!$&'()*+,;=:/%3F%23%5B%5D@", Rfc3986::encodePath("aAzZ09!$&'()*+,;=:/?#[]@"));
+    }
+
+    public function testEncodeQuery(): void
+    {
+        // Test that the method correctly encodes each character from the unreserved set, sub delims and gen delims
+        $this->assertEquals("aAzZ09!$&'()*+,;=:/?%23%5B%5D@", Rfc3986::encodeQuery("aAzZ09!$&'()*+,;=:/?#[]@"));
+    }
+
+    public function testEncodeFragment(): void
+    {
+        // Test that the method correctly encodes each character from the unreserved set, sub delims and gen delims
+        $this->assertEquals("aAzZ09!$&'()*+,;=:/?%23%5B%5D@", Rfc3986::encodeFragment("aAzZ09!$&'()*+,;=:/?#[]@"));
+    }
+
     public function testEncodeWithNoExclusions(): void
     {
         // Test that the method works in some general cases

--- a/test/Utilities/Rfc3986Test.php
+++ b/test/Utilities/Rfc3986Test.php
@@ -36,7 +36,10 @@ final class Rfc3986Test extends TestCase
     public function testEncodeUserInfo(): void
     {
         // Test that the method correctly encodes each character from the unreserved set, sub delims and gen delims
-        $this->assertEquals("aAzZ09!$&'()*+,;=:%2F%3F%23%5B%5D%40", Rfc3986::encodeUserInfo("aAzZ09!$&'()*+,;=:/?#[]@"));
+        $this->assertEquals(
+            "aAzZ09!$&'()*+,;=:%2F%3F%23%5B%5D%40",
+            Rfc3986::encodeUserInfo("aAzZ09!$&'()*+,;=:/?#[]@")
+        );
     }
 
     public function testEncodeHost(): void


### PR DESCRIPTION
This PR removes the code coverage ignore tags for the Rfc3986 encoding methods:

- Rfc3986::encodeUserInfo()
- Rfc3986::encodeHost()
- Rfc3986::encodePath()
- Rfc3986::encodeQuery()
- Rfc3986::encodeFragment()

Instead unit tests are implemented for these methods (previously we were operating under the assumption that these methods were adequately tested by the unit tests for Rfc3986::encode() as they are all essentially delegates to this method passing different values for the $excludedChars argument).

The only remaining instances of the code coverage ignore tags are for:

- The NullStream class which doesn't need testing.
- The conditional for preg_replace_callback() failure within Rfc3986::encode() I'm not sure what would cause this function to fail so adding a test that would cover this case isn't practical right now.