### PR TITLE
Colossalg - Implement RequestInterface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.vscode/
+/coverage/
 /vendor/

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Run the PHPUnit test suites with the following command:
 To additionally print the test coverage results to stdout run the following command:
 
 ```bash
->> .\vendor\bin\phpunit --coverage-text
+>> .\vendor\bin\phpunit --coverage-html="coverage"
 ```
 
 ### Running PHPStan Code Quality Analysis

--- a/src/Http/Message.php
+++ b/src/Http/Message.php
@@ -42,7 +42,7 @@ class Message implements MessageInterface
     /**
      * @see MessageInterface::withProtocolVersion()
      */
-    public function withProtocolVersion($version): Message
+    public function withProtocolVersion($version): static
     {
         if (!is_string($version)) {
             throw new \InvalidArgumentException("Argument 'version' must have type string.");
@@ -112,7 +112,7 @@ class Message implements MessageInterface
     /**
      * @see MessageInterface::withHeader()
      */
-    public function withHeader($name, $value): Message
+    public function withHeader($name, $value): static
     {
         if (!is_string($name)) {
             throw new \InvalidArgumentException("Argument 'name' must have type string.");
@@ -134,7 +134,7 @@ class Message implements MessageInterface
     /**
      * @see MessageInterface::withAddedHeader()
      */
-    public function withAddedHeader($name, $value): Message
+    public function withAddedHeader($name, $value): static
     {
         if (!is_string($name)) {
             throw new \InvalidArgumentException("Argument 'name' must have type string.");
@@ -159,7 +159,7 @@ class Message implements MessageInterface
     /**
      * @see MessageInterface::withoutHeader()
      */
-    public function withoutHeader($name): Message
+    public function withoutHeader($name): static
     {
         if (!is_string($name)) {
             throw new \InvalidArgumentException("Argument 'name' must have type string.");
@@ -184,7 +184,7 @@ class Message implements MessageInterface
     /**
      * @see MessageInterface::withBody()
      */
-    public function withBody(StreamInterface $body): Message
+    public function withBody(StreamInterface $body): static
     {
         $newMessage = clone $this;
         $newMessage->body = $body;

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Colossal\Http;
+
+use Colossal\Utilities\Rfc7230;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\UriInterface;
+
+class Request extends Message implements RequestInterface
+{
+    public const DEFAULT_METHOD     = "GET";
+    public const SUPPORTED_METHODS  = [
+        "GET",
+        "HEAD",
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE",
+        "CONNECT",
+        "OPTIONS",
+        "TRACE"
+    ];
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->requestTarget    = "";
+        $this->method           = self::DEFAULT_METHOD;
+        $this->uri              = new Uri();
+    }
+
+    /**
+     * Copy constructor.
+     */
+    public function __clone()
+    {
+        parent::__clone();
+    }
+
+    /**
+     * @see RequestInterface::getRequestTarget()
+     */
+    public function getRequestTarget(): string
+    {
+        if ($this->requestTarget === "") {
+            $requestTarget = "/";
+            if ($this->getUri()->getPath() !== "") {
+                $requestTarget = $this->getUri()->getPath();
+            }
+            if ($this->getUri()->getQuery() !== "") {
+                $requestTarget .= "?" . $this->uri->getQuery();
+            }
+
+            return $requestTarget;
+        } else {
+            return $this->requestTarget;
+        }
+    }
+
+    /**
+     * @see RequestInterface::withRequestTarget()
+     */
+    public function withRequestTarget($requestTarget): static
+    {
+        if (!is_string($requestTarget)) {
+            throw new \InvalidArgumentException("Argument 'requestTarget' must have type string.");
+        }
+        if (Rfc7230::IsRequestTargetInOriginForm($requestTarget)) {
+            throw new \InvalidArgumentException(
+                "Argument 'requestTarget' is in origin-form. " .
+                "Must be in absolute-form, authority-form or asterisk-form."
+            );
+        }
+        if (
+            !Rfc7230::IsRequestTargetInAbsoluteForm($requestTarget)     &&
+            !Rfc7230::IsRequestTargetInAuthorityForm($requestTarget)    &&
+            !Rfc7230::IsRequestTargetInAsteriskForm($requestTarget)
+        ) {
+            throw new \InvalidArgumentException(
+                "Argument 'requestTarget' is in an unrecognised form. " .
+                "Must be in absolute-form, authority-form or asterisk-form."
+            );
+        }
+
+        $newRequest = clone $this;
+        $newRequest->requestTarget = $requestTarget;
+
+        return $newRequest;
+    }
+
+    /**
+     * @see RequestInterface::getMethod()
+     */
+    public function getMethod(): string
+    {
+        return $this->method;
+    }
+
+    /**
+     * @see RequestInterface::withMethod()
+     */
+    public function withMethod($method): static
+    {
+        if (!is_string($method)) {
+            throw new \InvalidArgumentException("Argument 'method' must have type string.");
+        }
+        if (!in_array($method, self::SUPPORTED_METHODS)) {
+            throw new \InvalidArgumentException("The HTTP method '$method' is not supported.");
+        }
+
+        $newRequest = clone $this;
+        $newRequest->method = $method;
+
+        return $newRequest;
+    }
+
+    /**
+     * @see RequestInterface::getUri()
+     */
+    public function getUri(): UriInterface
+    {
+        return $this->uri;
+    }
+
+    /**
+     * @see RequestInterface::withUri()
+     */
+    public function withUri(UriInterface $uri, $preserveHost = false): static
+    {
+        if (!is_bool($preserveHost)) {
+            throw new \InvalidArgumentException("Argument 'preserveHost' must have type bool.");
+        }
+
+        $newRequest = clone $this;
+        $newRequest->uri = $uri;
+
+        if ($uri->getHost() !== "" && !($preserveHost && $newRequest->getHeader("Host") !== [])) {
+            $newRequest = $newRequest->withHeader("Host", $uri->getHost());
+        }
+
+        return $newRequest;
+    }
+
+    /**
+     * @var string The target for this request.
+     */
+    private string $requestTarget;
+
+    /**
+     * @var string The method for this request.
+     */
+    private string $method;
+
+    /**
+     * @var UriInterface The URI for this request.
+     */
+    private UriInterface $uri;
+}

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -28,6 +28,8 @@ class Request extends Message implements RequestInterface
      */
     public function __construct()
     {
+        parent::__construct();
+
         $this->requestTarget    = "";
         $this->method           = self::DEFAULT_METHOD;
         $this->uri              = new Uri();
@@ -39,6 +41,8 @@ class Request extends Message implements RequestInterface
     public function __clone()
     {
         parent::__clone();
+
+        $this->uri = clone $this->uri;
     }
 
     /**
@@ -48,7 +52,7 @@ class Request extends Message implements RequestInterface
     {
         if ($this->requestTarget === "") {
             $requestTarget = "/";
-            if ($this->getUri()->getPath() !== "") {
+            if ($this->getUri()->getPath()  !== "") {
                 $requestTarget = $this->getUri()->getPath();
             }
             if ($this->getUri()->getQuery() !== "") {
@@ -138,7 +142,8 @@ class Request extends Message implements RequestInterface
         $newRequest = clone $this;
         $newRequest->uri = $uri;
 
-        if ($uri->getHost() !== "" && !($preserveHost && $newRequest->getHeader("Host") !== [])) {
+        $hostHeaderLine = $newRequest->getHeaderLine("host");
+        if ($uri->getHost() !== "" && !($preserveHost && $newRequest->getHeaderLine("host") !== "")) {
             $newRequest = $newRequest->withHeader("Host", $uri->getHost());
         }
 

--- a/src/Http/Uri.php
+++ b/src/Http/Uri.php
@@ -125,7 +125,7 @@ class Uri implements UriInterface
     /**
      * @see UriInterface::withScheme()
      */
-    public function withScheme($scheme): Uri
+    public function withScheme($scheme): static
     {
         if (!is_string($scheme)) {
             throw new \InvalidArgumentException("Argument 'scheme' must have type string.");
@@ -149,7 +149,7 @@ class Uri implements UriInterface
     /**
      * @see UriInterface::withUserInfo()
      */
-    public function withUserInfo($user, $password = null): Uri
+    public function withUserInfo($user, $password = null): static
     {
         if (!is_string($user)) {
             throw new \InvalidArgumentException("Argument 'user' must have type string.");
@@ -173,7 +173,7 @@ class Uri implements UriInterface
     /**
      * @see UriInterface::withHost()
      */
-    public function withHost($host): Uri
+    public function withHost($host): static
     {
         if (!is_string($host)) {
             throw new \InvalidArgumentException("Argument 'host' must have type string.");
@@ -188,7 +188,7 @@ class Uri implements UriInterface
     /**
      * @see UriInterface::withPort()
      */
-    public function withPort($port): Uri
+    public function withPort($port): static
     {
         if (!is_null($port) && !is_int($port)) {
             throw new \InvalidArgumentException("Argument 'port' must have type null or int.");
@@ -210,7 +210,7 @@ class Uri implements UriInterface
     /**
      * @see UriInterface::withPath()
      */
-    public function withPath($path): Uri
+    public function withPath($path): static
     {
         if (!is_string($path)) {
             throw new \InvalidArgumentException("Argument 'path' must have type string.");
@@ -225,7 +225,7 @@ class Uri implements UriInterface
     /**
      * @see UriInterface::withQuery()
      */
-    public function withQuery($query): Uri
+    public function withQuery($query): static
     {
         if (!is_string($query)) {
             throw new \InvalidArgumentException("Argument 'query' must have type string.");
@@ -240,7 +240,7 @@ class Uri implements UriInterface
     /**
      * @see UriInterface::withFragment()
      */
-    public function withFragment($fragment): Uri
+    public function withFragment($fragment): static
     {
         if (!is_string($fragment)) {
             throw new \InvalidArgumentException("Argument 'fragment' must have type string.");

--- a/src/Utilities/Rfc3986.php
+++ b/src/Utilities/Rfc3986.php
@@ -186,12 +186,12 @@ class Rfc3986
      *
      * See https://www.rfc-editor.org/rfc/rfc3986#section-3.2.3
      *
-     * @param string $port The port component to check.
+     * @param int|string $port The port component to check.
      * @return bool Whether $port represents a valid port component.
      */
-    public static function isValidPort(string $port): bool
+    public static function isValidPort(int|string $port): bool
     {
-        return boolval(preg_match("/^[0-9]*$/", $port));
+        return is_int($port) || boolval(preg_match("/^[0-9]+$/", $port));
     }
 
     /**
@@ -208,7 +208,7 @@ class Rfc3986
     {
         return (
             self::isPercentEncodingValid($path) &&
-            boolval(preg_match("/^[%a-zA-Z0-9\-._~!$&'()*+,;=:@\/]+$/", $path))
+            boolval(preg_match("/^[%a-zA-Z0-9\-._~!$&'()*+,;=:@\/]*$/", $path))
         );
     }
 
@@ -383,9 +383,7 @@ class Rfc3986
         );
 
         if (is_null($encoded)) {
-            // @codeCoverageIgnoreStart
             throw new \RuntimeException("An error occurred trying to perform percent encoding for $str.");
-            // @codeCoverageIgnoreEnd
         }
 
         return $encoded;
@@ -419,7 +417,15 @@ class Rfc3986
         }
     }
 
-    private static function isPercentEncodingValid(string $str): bool
+    /**
+     * Returns whether all percent encodings of a given string are valid as described by RFC 3986.
+     *
+     * See https://www.rfc-editor.org/rfc/rfc3986#section-2.1
+     *
+     * @param string $str The string to validate.
+     * @return bool Whether all percent encodings found within $str are valid.
+     */
+    public static function isPercentEncodingValid(string $str): bool
     {
         try {
             self::validatePercentEncoding($str);

--- a/src/Utilities/Rfc3986.php
+++ b/src/Utilities/Rfc3986.php
@@ -37,20 +37,74 @@ class Rfc3986
     ];
 
     /**
+     * Parses a well formed URI in to its underlying components.
+     *     - Scheme
+     *     - Authority
+     *     - Path
+     *     - Query
+     *     - Fragment
+     *
+     * See https://www.rfc-editor.org/rfc/rfc3986#appendix-B
+     *
+     * @param string $uri The URI to be parsed.
+     * @return array<null|string> An object containing the URI's underlying components.
+     * @throws \InvalidArgumentException If $uri is not a well formed URI.
+     */
+    public static function parseUriIntoComponents(string $uri): array
+    {
+        $matches = [];
+        $success = preg_match(
+            "%^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?%",
+            $uri,
+            $matches,
+            PREG_UNMATCHED_AS_NULL
+        );
+        if ($success) {
+            $components = [];
+            $components["scheme"]       = $matches[2];
+            $components["authority"]    = $matches[4];
+            $components["path"]         = $matches[5];
+            $components["query"]        = $matches[7];
+            $components["fragment"]     = $matches[9];
+            return $components;
+        }
+
+        throw new \InvalidArgumentException(
+            "Could not parse URI '$uri' in to components." .
+            "Please check that the URI is well formed as per RFC3986."
+        );
+    }
+
+    /**
+     * Determines whether a string represents a valid scheme component as per RFC3986.
+     *
+     * See https://www.rfc-editor.org/rfc/rfc3986#section-3.1
+     *
+     * The string is assumed to have already been percent encoded.
+     *
+     * @param string $scheme The scheme component to check.
+     * @return bool Whether $scheme represents a valid scheme component.
+     */
+    public static function isValidScheme(string $scheme): bool
+    {
+        return boolval(preg_match("/^[a-z][a-z0-9+\-.]*$/", $scheme));
+    }
+
+    /**
      * Performs encoding of the scheme component as per RFC 3986.
      *
      * See https://www.rfc-editor.org/rfc/rfc3986#section-3.1
      *
-     * @param string $scheme The user info component to encode.
+     * @param string $scheme The scheme component to encode.
      * @return string $scheme once it has been encoded.
      * @throws \InvalidArgumentException If $scheme is not valid as per RFC 3986.
      */
     public static function encodeScheme(string $scheme): string
     {
-        if (!preg_match("/[a-zA-Z][a-zA-Z0-9\+\-\.]*/", $scheme)) {
+        if (!self::isValidScheme(strtolower($scheme))) {
             throw new \InvalidArgumentException(
                 "Argument 'scheme' must start with a letter and may only contain " .
-                "characters from the following set: { a-z, A-Z, 0-9, +, -, .}."
+                "characters from the following set: { a-z, 0-9, +, -, .}."
             );
         }
 
@@ -76,6 +130,28 @@ class Rfc3986
         return self::encode(
             $userInfo,
             array_merge(self::UNRESERVED, self::SUB_DELIMS, [":"])
+        );
+    }
+
+    /**
+     * Determines whether a string represents a valid host component as per RFC 3986.
+     *
+     * See https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2
+     *
+     * The string is assumed to have already been percent encoded.
+     *
+     * @param string $host The host component to check.
+     * @return bool Whether $host represents a valid host component.
+     */
+    public static function isValidHost(string $host)
+    {
+        if (self::isIPLiteral($host)) {
+            return true;
+        }
+
+        return (
+            self::isPercentEncodingValid($host) &&
+            boolval(preg_match("/^[%a-zA-Z0-9\-._~!$&'()*+,;=]+$/", $host))
         );
     }
 
@@ -106,6 +182,56 @@ class Rfc3986
     }
 
     /**
+     * Determines whether a string represents a valid port component as per RFC 3986.
+     *
+     * See https://www.rfc-editor.org/rfc/rfc3986#section-3.2.3
+     *
+     * @param string $port The port component to check.
+     * @return bool Whether $port represents a valid port component.
+     */
+    public static function isValidPort(string $port): bool
+    {
+        return boolval(preg_match("/^[0-9]*$/", $port));
+    }
+
+    /**
+     * Determines whether a string represents a valid path component as per RFC 3986.
+     *
+     * See https://www.rfc-editor.org/rfc/rfc3986#section-3.3
+     *
+     * The string is assumed to have already been percent encoded.
+     *
+     * @param string $path The path component to check.
+     * @return bool Whether $path represents a valid path component.
+     */
+    public static function isValidPath(string $path): bool
+    {
+        return (
+            self::isPercentEncodingValid($path) &&
+            boolval(preg_match("/^[%a-zA-Z0-9\-._~!$&'()*+,;=:@\/]+$/", $path))
+        );
+    }
+
+    /**
+     * Determines whether a string represents a valid absolute path component as per RFC 3986.
+     *
+     * See https://www.rfc-editor.org/rfc/rfc3986#section-3.3
+     *
+     * The string is assumed to have already been percent encoded.
+     *
+     * @param string $path The path component to check.
+     * @return bool Whether $path represents a valid absolute path component.
+     */
+    public static function isValidAbsolutePath(string $path): bool
+    {
+        if (!str_starts_with($path, "/") || str_starts_with($path, "//")) {
+            return false;
+        }
+
+        return self::isValidPath($path);
+    }
+
+    /**
      * Performs encoding of the path component as per RFC 3986.
      *
      * See https://www.rfc-editor.org/rfc/rfc3986#section-3.3
@@ -128,6 +254,24 @@ class Rfc3986
     }
 
     /**
+     * Determines whether a string represents a valid query component as per RFC3986.
+     *
+     * See https://www.rfc-editor.org/rfc/rfc3986#section-3.4
+     *
+     * The string is assumed to have already been percent encoded.
+     *
+     * @param string $query The query component to check.
+     * @return bool Whether $query represents a valid query component.
+     */
+    public static function isValidQuery(string $query): bool
+    {
+        return (
+            self::isPercentEncodingValid($query) &&
+            boolval(preg_match("/^[%a-zA-Z0-9\-._~!$&'()*+,;=:@\/?]+$/", $query))
+        );
+    }
+
+    /**
      * Performs encoding of the query component as per RFC 3986.
      *
      * See https://www.rfc-editor.org/rfc/rfc3986#section-3.4
@@ -146,6 +290,24 @@ class Rfc3986
         return self::encode(
             $query,
             array_merge(self::UNRESERVED, self::SUB_DELIMS, [":", "@", "/", "?"])
+        );
+    }
+
+    /**
+     * Determines whether a string represents a valid fragment component as per RFC3986.
+     *
+     * See https://www.rfc-editor.org/rfc/rfc3986#section-3.4
+     *
+     * The string is assumed to have already been percent encoded.
+     *
+     * @param string $fragment The fragment component to check.
+     * @return bool Whether $fragment represents a valid fragment component.
+     */
+    public static function isValidFragment(string $fragment): bool
+    {
+        return (
+            self::isPercentEncodingValid($fragment) &&
+            boolval(preg_match("/^[%a-zA-Z0-9\-._~!$&'()*+,;=:@\/?]+$/", $fragment))
         );
     }
 
@@ -255,6 +417,17 @@ class Rfc3986
         if (preg_match("/(%(?![a-fA-F0-9]{2}).{0,2})/", $str, $matches)) {
             throw new \InvalidArgumentException("Argument 'str' contains invalid percent encoding '$matches[0]'.");
         }
+    }
+
+    private static function isPercentEncodingValid(string $str): bool
+    {
+        try {
+            self::validatePercentEncoding($str);
+        } catch (\InvalidArgumentException) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/src/Utilities/Rfc7230.php
+++ b/src/Utilities/Rfc7230.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Colossal\Utilities;
+
+class Rfc7230
+{
+    /**
+     * Returns whether a request target is in valid origin-form.
+     *
+     * See https://www.rfc-editor.org/rfc/rfc7230#section-5.3.1
+     *
+     * @param string $requestTarget The request target to check.
+     * @return bool Whether $requestTarget is in valid origin-form.
+     */
+    public static function isRequestTargetInOriginForm(string $requestTarget): bool
+    {
+        $matches = [];
+        if (preg_match("/^([^?]+)+$/", $requestTarget, $matches, PREG_UNMATCHED_AS_NULL)) {
+            $isPathOk  = !is_null($matches[1]) && Rfc3986::isValidAbsolutePath($matches[1]);
+            $isQueryOk =  is_null($matches[2]) || Rfc3986::isValidQuery($matches[2]);
+
+            return $isPathOk && $isQueryOk;
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns whether a request target is in valid absolute-form.
+     *
+     * See https://www.rfc-editor.org/rfc/rfc7230#section-5.3.2
+     *
+     * @param string $requestTarget The request target to check.
+     * @return bool Whether $requestTarget is in valid absolute-form.
+     */
+    public static function isRequestTargetInAbsoluteForm(string $requestTarget): bool
+    {
+        $uriComponents = [];
+        try {
+            $uriComponents = Rfc3986::parseUriIntoComponents($requestTarget);
+        } catch (\InvalidArgumentException $e) {
+        }
+
+        return is_null($uriComponents["fragment"]);
+    }
+
+    /**
+     * Returns whether a request target is in valid authority-form.
+     *
+     * See https://www.rfc-editor.org/rfc/rfc7230#section-5.3.3
+     *
+     * @param string $requestTarget The request target to check.
+     * @return bool Whether $requestTarget is in valid authority-form.
+     */
+    public static function isRequestTargetInAuthorityForm(string $requestTarget): bool
+    {
+        $matches = [];
+        if (preg_match("/^([^:]+)+$/", $requestTarget, $matches, PREG_UNMATCHED_AS_NULL)) {
+            $isHostOk = !is_null($matches[1]) && Rfc3986::isValidHost($matches[1]);
+            $isPortOk =  is_null($matches[2]) || Rfc3986::isValidPort($matches[2]);
+
+            return $isHostOk && $isPortOk;
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns whether a request target is in valid asterisk-form.
+     *
+     * See https://www.rfc-editor.org/rfc/rfc7230#section-5.3.4
+     *
+     * @param string $requestTarget The request target to check.
+     * @return bool Whether $requestTarget is in valid asterisk-form.
+     */
+    public static function isRequestTargetInAsteriskForm(string $requestTarget): bool
+    {
+        return $requestTarget === "*";
+    }
+}

--- a/test/Http/RequestTest.php
+++ b/test/Http/RequestTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Colossal\Utilities\Testing;
+
+use Colossal\Http\Request;
+use Colossal\Http\Uri;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Colossal\Http\Request
+ * @uses \Colossal\Http\Message
+ * @uses \Colossal\Http\Uri
+ * @uses \Colossal\Utilities\Rfc3986
+ * @uses \Colossal\Utilities\Rfc7230
+ * @uses \Colossal\Utilities\Utilities
+ */
+final class RequestTest extends TestCase
+{
+    private Request $request;
+
+    public function setUp(): void
+    {
+        $this->request = new Request();
+    }
+
+    public function testGetRequestTarget(): void
+    {
+        $uriWithPath            = (new Uri())->withPath("/users");
+        $uriWithPathAndQuery    = (new Uri())->withPath("/users")->withQuery("id=1");
+
+        // Test that if a request target has been set then that is returned
+        $newUri = $this->request
+            ->withUri($uriWithPath)
+            ->withRequestTarget("http://localhost:8080/user/1");
+        $this->assertEquals("http://localhost:8080/user/1", $newUri->getRequestTarget());
+
+        // Test that if no request target has been set but there is a Uri the origin-form of the Uri is returned
+
+        $newUri = $this->request->withUri($uriWithPath);
+        $this->assertEquals("/users", $newUri->getRequestTarget());
+
+        $newUri = $this->request->withUri($uriWithPathAndQuery);
+        $this->assertEquals("/users?id=1", $newUri->getRequestTarget());
+
+        // Test that if no request target and no Uri are available then "/" is returned
+        $this->assertEquals("/", $this->request->getRequestTarget());
+    }
+
+    public function testWithRequestTarget(): void
+    {
+        // Test that the method works in the general case
+        $newRequest = $this->request->withRequestTarget("http://localhost:8000/users?id=1");
+        $this->assertEquals("/", $this->request->getRequestTarget());
+        $this->assertEquals("http://localhost:8000/users?id=1", $newRequest->getRequestTarget());
+    }
+
+    public function testWithRequestTargetThrowsForNonStringRequestTargetArgument(): void
+    {
+        // Test that the method throws when we provide it with a non string value for the argument 'requestTarget'
+        $this->expectException(\InvalidArgumentException::class);
+        $this->request->withRequestTarget(1);
+    }
+
+    public function testWithRequestTargetThrowsForOriginForm(): void
+    {
+        // Test that the method throws when the string argument 'requestTarget' is in origin form
+        $this->expectException(\InvalidArgumentException::class);
+        $this->request->withRequestTarget("/path?query=abc");
+    }
+
+    public function testWithRequestTargetThrowsForUnrecognisedForm(): void
+    {
+        // Test that the method throws when the string argument 'requestTarget' is in unrecognised form
+        $this->expectException(\InvalidArgumentException::class);
+        $this->request->withRequestTarget("[]");
+    }
+
+    public function testWithMethod(): void
+    {
+        // Test that the method works in the general case
+        $newRequest = $this->request->withMethod("POST");
+        $this->assertEquals("GET", $this->request->getMethod());
+        $this->assertEquals("POST", $newRequest->getMethod());
+    }
+
+    public function testWithMethodThrowsForNonStringMethodArgument(): void
+    {
+        // Test that the method throws when we provide it with a non string value for the argument 'method'
+        $this->expectException(\InvalidArgumentException::class);
+        $this->request->withMethod(1); /** @phpstan-ignore-line */
+    }
+
+    public function testWithMethodThrowsForUnsuportedHttpMethod(): void
+    {
+        // Test that the method throws when we provide it with an unsupported Http method
+        $this->expectException(\InvalidArgumentException::class);
+        $this->request->withMethod("UNSUPPORTED_METHOD");
+    }
+
+    public function testWithURi(): void
+    {
+        $uriWithoutHost = new Uri();
+        $uriWithHost    = (new Uri())->withHost("www.google.com");
+
+        // Test when the Uri doesn't contain a host component, the host header is non-empty and preserve host is false
+        $newRequest = $this->request
+            ->withHeader("host", "localhost")
+            ->withUri($uriWithoutHost);
+        $this->assertEquals(["localhost"], $newRequest->getHeader("host"));
+
+        // Test when the Uri does contain a host component, the host header is non-empty and preserve host is false
+        $newRequest = $this->request
+            ->withHeader("host", "localhost")
+            ->withUri($uriWithHost);
+        $this->assertEquals(["www.google.com"], $newRequest->getHeader("host"));
+
+        // Test when the Uri doesn't contain a host component, the host header is empty and preserve host is true
+        $newRequest = $this->request->withUri($uriWithoutHost, true);
+        $this->assertEquals([], $newRequest->getHeader("host"));
+
+        // Test when the Uri does contain a host component, the host header is empty and preserve host is true
+        $newRequest = $this->request->withUri($uriWithHost, true);
+        $this->assertEquals(["www.google.com"], $newRequest->getHeader("host"));
+
+        // Test when the Uri does contain a host component, the host header is non-empty and preserve host is true
+        $newRequest = $this->request
+            ->withHeader("host", "localhost")
+            ->withUri($uriWithHost, true);
+        $this->assertEquals(["localhost"], $newRequest->getHeader("host"));
+    }
+
+    public function testWithUriThrowsForNonBoolPreserveHostArgument(): void
+    {
+        // Test that the method throws when we provide it with a non bool value for the argument 'preserveHost'
+        $this->expectException(\InvalidArgumentException::class);
+        $this->request->withUri(new Uri(), 1); /** @phpstan-ignore-line */
+    }
+}

--- a/test/Utilities/Rfc7230Test.php
+++ b/test/Utilities/Rfc7230Test.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Colossal\Utilities\Testing;
+
+use Colossal\Utilities\Rfc7230;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Colossal\Utilities\Rfc7230
+ * @uses \Colossal\Utilities\Rfc3986
+ */
+final class Rfc7230Test extends TestCase
+{
+    public function testIsRequestTargetInOriginForm(): void
+    {
+        // Test when the request target contains a valid absolute path and a valid query component
+        $this->assertTrue(Rfc7230::isRequestTargetInOriginForm("/path?query=abc"));
+
+        // Test when the request target contains a valid absolute path and no query component
+        $this->assertTrue(Rfc7230::isRequestTargetInOriginForm("/path"));
+        $this->assertFalse(Rfc7230::isRequestTargetInOriginForm("/path?"));
+
+        // Test when the request target contains a valid absolute path and an invalid query component
+        $this->assertFalse(Rfc7230::isRequestTargetInOriginForm("/path?query=abc#"));
+
+        // Test when the request target contains an invalid absolute path and a valid query component
+        $this->assertFalse(Rfc7230::isRequestTargetInOriginForm("path?query=abc"));
+        $this->assertFalse(Rfc7230::isRequestTargetInOriginForm("//path?query=abc"));
+        $this->assertFalse(Rfc7230::isRequestTargetInOriginForm("##path?query=abc"));
+
+        // Test when the request target is empty
+        $this->assertFalse(Rfc7230::isRequestTargetInOriginForm(""));
+    }
+
+    public function testIsRequestTargetInAbsoluteForm(): void
+    {
+        // Test when the scheme, path and query components are correct and the fragment is absent
+        $this->assertTrue(Rfc7230::isRequestTargetInAbsoluteForm("http://localhost:8000"));
+        $this->assertTrue(Rfc7230::isRequestTargetInAbsoluteForm("http://localhost:8000/"));
+        $this->assertTrue(Rfc7230::isRequestTargetInAbsoluteForm("http://localhost:8000/users/1"));
+        $this->assertTrue(Rfc7230::isRequestTargetInAbsoluteForm("http://localhost:8000/users?id=1"));
+
+        // Test when the scheme, path and query components are correct and the fragment is present
+        $this->assertFalse(Rfc7230::isRequestTargetInAbsoluteForm("http://localhost:8000#frag"));
+        $this->assertFalse(Rfc7230::isRequestTargetInAbsoluteForm("http://localhost:8000/#frag"));
+        $this->assertFalse(Rfc7230::isRequestTargetInAbsoluteForm("http://localhost:8000/users/1#frag"));
+        $this->assertFalse(Rfc7230::isRequestTargetInAbsoluteForm("http://localhost:8000/users?id=1#frag"));
+
+        // Test when either the scheme, path or query components are incorrect
+        $this->assertFalse(Rfc7230::isRequestTargetInAbsoluteForm("Http://localhost:8000/users?username=John_Doe"));
+        $this->assertFalse(Rfc7230::isRequestTargetInAbsoluteForm("http://localhost:8000/invalid[]path?id=1"));
+        $this->assertFalse(Rfc7230::isRequestTargetInAbsoluteForm("http://localhost:8000/users?id=1[]"));
+
+        // Test when the request target is empty
+        $this->assertFalse(Rfc7230::isRequestTargetInAbsoluteForm(""));
+    }
+
+    public function testIsRequestTargetInAuthorityForm(): void
+    {
+        // Test when the host and port components are present and correct
+        $this->assertTrue(Rfc7230::isRequestTargetInAuthorityForm("localhost:8080"));
+
+        // Test when the host is present and correct, and the port is absent
+        $this->assertTrue(Rfc7230::isRequestTargetInAuthorityForm("localhost"));
+
+        // Test when the host is present and correct, and the port is present but incorrect
+        $this->assertFalse(Rfc7230::isRequestTargetInAuthorityForm("localhost:[]"));
+
+        // Test when the host is present but incorrect
+        $this->assertFalse(Rfc7230::isRequestTargetInAuthorityForm("[]"));
+        $this->assertFalse(Rfc7230::isRequestTargetInAuthorityForm("[]:8080"));
+
+        // Test when the request target is empty
+        $this->assertFalse(Rfc7230::isRequestTargetInAuthorityForm(""));
+    }
+
+    public function testIsRequestTargetInAsteriskForm(): void
+    {
+        // Just for the sake of the code coverage metrics really
+        $this->assertTrue(Rfc7230::isRequestTargetInAsteriskForm("*"));
+    }
+}


### PR DESCRIPTION
This pull request creates a class Colossal\Http\Request that implements the Psr\Http\Message\RequestInterface interface.

The behaviour was implemented as outlined in the comments for the RequestInterface methods.

Some of the behaviour related to the RFC 7230 (https://www.rfc-editor.org/rfc/rfc7230). This has been implemented in a separate class Colossal\Utilities\Rfc7230 and is utilized from Colossal\Http\Request.

Significant changes were also required to Colossal\Utilities\Rfc3986 to add some helper methods for checking the validity of Uri components, etc.

Associated unit tests have been added as well to verify behaviour.