### PR TITLE
Colossalg - Implement UploadedFileInterface

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,5 +5,5 @@ parameters:
         - test
     excludePaths:
         analyse:
-            - test/ForcedFailures.php
+            - test/PhpOverrides.php
     treatPhpDocTypesAsCertain: false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,4 +3,7 @@ parameters:
     paths:
         - src
         - test
+    excludePaths:
+        analyse:
+            - test/ForcedFailures.php
     treatPhpDocTypesAsCertain: false

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" bootstrap="vendor/autoload.php" executionOrder="depends,defects" beStrictAboutOutputDuringTests="true" failOnRisky="true" failOnWarning="true" cacheDirectory=".phpunit.cache" requireCoverageMetadata="true" beStrictAboutCoverageMetadata="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" bootstrap="test/autoload.php" executionOrder="depends,defects" beStrictAboutOutputDuringTests="true" failOnRisky="true" failOnWarning="true" cacheDirectory=".phpunit.cache" requireCoverageMetadata="true" beStrictAboutCoverageMetadata="true">
   <testsuites>
     <testsuite name="default">
       <directory suffix="Test.php">test</directory>

--- a/src/Http/Message.php
+++ b/src/Http/Message.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Colossal\Http;
 
-use Colossal\Http\Stream;
+use Colossal\Http\Stream\NullStream;
 use Colossal\Utilities\Utilities;
 use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\StreamInterface;
@@ -21,7 +21,7 @@ class Message implements MessageInterface
     {
         $this->protocolVersion  = self::DEFAULT_PROTOCOL_VERSION;
         $this->headers          = [];
-        $this->body             = new Stream\NullStream();
+        $this->body             = new NullStream();
     }
 
     /**

--- a/src/Http/UploadedFile.php
+++ b/src/Http/UploadedFile.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Colossal\Http;
+
+use Colossal\Http\Stream\ResourceStream;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UploadedFileInterface;
+
+class UploadedFile implements UploadedFileInterface
+{
+    /**
+     * Constructor.
+     * @param string $filePath The file name or path for this uploaded file.
+     * @param null|int $size The size of this uploaded file.
+     * @param int $error The error for this uploaded file.
+     * @param null|string $clientFileName The client file name for this uploaded file.
+     * @param null|string $clientMediaType The client media type for this uploaded file.
+     */
+    public function __construct(
+        string $filePath,
+        null|int $size,
+        int $error,
+        null|string $clientFileName,
+        null|string $clientMediaType
+    ) {
+        $this->hasMoved         = false;
+        $this->filePath         = $filePath;
+        $this->stream           = null;
+        $this->size             = $size;
+        $this->error            = $error;
+        $this->clientFileName   = $clientFileName;
+        $this->clientMediaType  = $clientMediaType;
+    }
+
+    /**
+     * @see UploadedFileInterface::getStream()
+     */
+    public function getStream(): StreamInterface
+    {
+        $this->assertHasNotMoved();
+
+        // Lazy initialization of the stream (first opening of stream, or stream has been closed externally).
+        if (is_null($this->stream) || !$this->stream->isReadable()) {
+            $resource = fopen($this->filePath, "r");
+            if ($resource === false) {
+                throw new \RuntimeException("Could not open file path '$this->filePath' for reading.");
+            }
+            $this->stream = new ResourceStream($resource);
+        }
+
+        return $this->stream;
+    }
+
+    /**
+     * @see UploadedFileInterface::moveTo()
+     */
+    public function moveTo($targetPath): void
+    {
+        $this->assertHasNotMoved();
+
+        if (is_dir($targetPath)) {
+            throw new \RuntimeException("Path '$targetPath' coincides with existing directory.");
+        }
+        if (is_file($targetPath) && !is_writable($targetPath)) {
+            throw new \RuntimeException("Path '$targetPath' coincides with existing unwritable file.");
+        }
+
+        if (!is_null($this->stream)) {
+            $this->stream->close();
+        }
+
+        if (php_sapi_name() === 'cli' || defined('STDIN')) {
+            if (!rename($this->filePath, $targetPath)) {
+                throw new \RuntimeException("Call to rename() returned false for '$this->filePath'.");
+            }
+        } else {
+            if (!is_uploaded_file($this->filePath)) {
+                throw new \RuntimeException("Call to is_uploaded_file() returned false for '$this->filePath'.");
+            }
+            if (!move_uploaded_file($this->filePath, $targetPath)) {
+                throw new \RuntimeException("Call to move_uploaded_file() returned false for '$this->filePath'.");
+            }
+        }
+
+        $this->hasMoved = true;
+    }
+
+    /**
+     * @see UploadedFileInterface::getSize()
+     */
+    public function getSize(): null|int
+    {
+        return $this->size;
+    }
+
+    /**
+     * @see UploadedFileInterface::getError()
+     */
+    public function getError(): int
+    {
+        return $this->error;
+    }
+
+    /**
+     * @see UploadedFileInterface::getClientFilename()
+     */
+    public function getClientFilename(): null|string
+    {
+        return $this->clientFileName;
+    }
+
+    /**
+     * @see UploadedFileInterface::getClientMediaType()
+     */
+    public function getClientMediaType(): null|string
+    {
+        return $this->clientMediaType;
+    }
+
+    private function assertHasNotMoved(): void
+    {
+        if ($this->hasMoved) {
+            throw new \RuntimeException("The uploaded file has been previously moved.");
+        }
+    }
+
+    /**
+     * @var bool Whether this uploaded file has been moved before.
+     */
+    private bool $hasMoved;
+
+    /**
+     * @var string The file path for this uploaded file.
+     */
+    private string $filePath;
+
+    /**
+     * @var null|StreamInterface The stream for this uploaded file (read-only).
+     */
+    private null|StreamInterface $stream;
+
+    /**
+     * @var null|int The size of this uploaded file.
+     */
+    private null|int $size;
+
+    /**
+     * @var int The error for this uploaded file.
+     */
+    private int $error;
+
+    /**
+     * @var null|string The client file name for this uploaded file.
+     */
+    private null|string $clientFileName;
+
+    /**
+     * @var null|string The client media type for this uploaded file.
+     */
+    private null|string $clientMediaType;
+}

--- a/src/Utilities/Rfc3986.php
+++ b/src/Utilities/Rfc3986.php
@@ -382,7 +382,7 @@ class Rfc3986
             $encoded
         );
 
-        if (is_null($encoded)) {
+        if (is_array($encoded) || is_null($encoded)) {
             throw new \RuntimeException("An error occurred trying to perform percent encoding for $str.");
         }
 

--- a/test/ForcedFailures.php
+++ b/test/ForcedFailures.php
@@ -1,0 +1,177 @@
+<?php
+
+// This file contains classes and functions which allow the forced failure of
+// PHP built in functions. To do so we take advantage of how PHP resolves the
+// symbols.
+//
+// If PHP encounters a function it will first look for a corresponding
+// symbol of that name within the current namespace, if it is not found then
+// it will fall back to the global namespace and search for the symbol there.
+//
+// We declare functions of the same name and signature as the PHP built in
+// functions to do the following based upon flags set in the corresponding
+// singletons:
+//     1. If the flag is set to true, then mock the failure of the function.
+//        (Generally means to return null or false).
+//     2. Otherwise, delegate to the PHP built in function.
+
+declare(strict_types=1);
+
+namespace Colossal
+{
+    class ForcedFailuresBase
+    {
+        protected static null|self $instance = null;
+
+        public static function getInstance(): static
+        {
+            if (is_null(self::$instance)) {
+                static::reset();
+            }
+            return static::$instance;
+        }
+
+        public static function reset(): void
+        {
+            static::$instance = new static();
+        }
+    }
+}
+
+namespace Colossal\Http\Stream
+{
+    // phpcs:ignore
+    final class ForcedFailures extends \Colossal\ForcedFailuresBase
+    {
+        public function __construct(
+            public bool $fstat = false,
+            public bool $ftell = false,
+            public bool $fwrite = false,
+            public bool $fread = false,
+            public bool $stream_get_contents = false
+        ) {
+        }
+    }
+
+    function fstat($stream): array|false
+    {
+        if (ForcedFailures::getInstance()->fstat) {
+            ForcedFailures::reset();
+            return false;
+        } else {
+            return \fstat($stream);
+        }
+    }
+
+    function ftell($stream): int|false
+    {
+        if (ForcedFailures::getInstance()->ftell) {
+            ForcedFailures::reset();
+            return false;
+        } else {
+            return \ftell($stream);
+        }
+    }
+
+    function fwrite($stream, string $data, ?int $length = null): int|false
+    {
+        if (ForcedFailures::getInstance()->fwrite) {
+            ForcedFailures::reset();
+            return false;
+        } else {
+            return \fwrite($stream, $data, $length);
+        }
+    }
+
+    function fread($stream, int $length): string|false
+    {
+        if (ForcedFailures::getInstance()->fread) {
+            ForcedFailures::reset();
+            return false;
+        } else {
+            return \fread($stream, $length);
+        }
+    }
+
+    function stream_get_contents($stream, ?int $length = null, int $offset = -1): string|false
+    {
+        if (ForcedFailures::getInstance()->stream_get_contents) {
+            ForcedFailures::reset();
+            return false;
+        } else {
+            return \stream_get_contents($stream, $length, $offset);
+        }
+    }
+}
+
+namespace Colossal\Utilities
+{
+    // phpcs:ignore
+    final class ForcedFailuresUtilities
+    {
+        public static null|self $instance = null;
+
+        public static function getInstance(): self
+        {
+            if (is_null(self::$instance)) {
+                self::reset();
+            }
+            return self::$instance;
+        }
+
+        public static function reset(): void
+        {
+            self::$instance = new self();
+        }
+
+        public function __construct(
+            public bool $preg_match = false,
+            public bool $preg_replace_callback = false
+        ) {
+        }
+    }
+
+    function preg_match(
+        string $pattern,
+        string $subject,
+        array &$matches = null,
+        int $flags = 0,
+        int $offset = 0
+    ): int|false {
+        if (ForcedFailuresUtilities::getInstance()->preg_match) {
+            ForcedFailuresUtilities::reset();
+            return false;
+        } else {
+            return \preg_match(
+                $pattern,
+                $subject,
+                $matches,
+                $flags,
+                $offset
+            );
+        }
+    }
+
+    function preg_replace_callback(
+        string|array $pattern,
+        callable $callback,
+        string|array $subject,
+        int $limit = -1,
+        int &$count = null,
+        int $flags = 0
+    ): string|array|null {
+        if (ForcedFailuresUtilities::getInstance()->preg_replace_callback) {
+            ForcedFailuresUtilities::reset();
+            return null;
+        } else {
+            return \preg_replace_callback(
+                $pattern,
+                $callback,
+                $subject,
+                $limit,
+                $count,
+                $flags
+            );
+        }
+    }
+}

--- a/test/Http/MessageTest.php
+++ b/test/Http/MessageTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Colossal\Http\Testing;
+namespace Colossal\Http;
 
 use Colossal\Http\Message;
 use Colossal\Http\Stream\NullStream;

--- a/test/Http/RequestTest.php
+++ b/test/Http/RequestTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Colossal\Utilities\Testing;
+namespace Colossal\Http;
 
 use Colossal\Http\Request;
 use Colossal\Http\Uri;

--- a/test/Http/Stream/ResourceStreamTest.php
+++ b/test/Http/Stream/ResourceStreamTest.php
@@ -170,7 +170,7 @@ final class ResourceStreamTest extends TestCase
         $resourceStream->tell();
     }
 
-    public function testTellThrowsIfFstatFails(): void
+    public function testTellThrowsIfFtellFails(): void
     {
         // Test that the method throws if ftell() fails
         $this->phpOverrides->ftell = false;

--- a/test/Http/Stream/ResourceStreamTest.php
+++ b/test/Http/Stream/ResourceStreamTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Colossal\Http\Stream;
 
-use Colossal\PhpOverrides;
 use Colossal\Http\Stream\ResourceStream;
+use Colossal\PhpOverrides;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/test/Http/Stream/ResourceStreamTest.php
+++ b/test/Http/Stream/ResourceStreamTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Colossal\Http\Stream;
 
-use Colossal\Http\Stream\ForcedFailures;
+use Colossal\PhpOverrides;
 use Colossal\Http\Stream\ResourceStream;
 use PHPUnit\Framework\TestCase;
 
@@ -17,8 +17,8 @@ final class ResourceStreamTest extends TestCase
 
     public function setUp(): void
     {
-        ForcedFailures::reset();
-        $this->forcedFailures = ForcedFailures::getInstance();
+        PhpOverrides::reset();
+        $this->phpOverrides = PhpOverrides::getInstance();
     }
 
     public function testCreateWithProvidedResourceThrowsForNonResourceArgument(): void
@@ -143,7 +143,7 @@ final class ResourceStreamTest extends TestCase
     public function testGetSizeThrowsIfFstatFails(): void
     {
         // Test that the method throws if fstat() fails
-        $this->forcedFailures->fstat = true;
+        $this->phpOverrides->fstat = false;
         $this->expectExceptionMessage("Call to fstat() failed.");
         $this->createReadWriteResourceStream()->getSize();
     }
@@ -173,7 +173,7 @@ final class ResourceStreamTest extends TestCase
     public function testTellThrowsIfFstatFails(): void
     {
         // Test that the method throws if ftell() fails
-        $this->forcedFailures->ftell = true;
+        $this->phpOverrides->ftell = false;
         $this->expectExceptionMessage("Call to ftell() failed.");
         $this->createReadWriteResourceStream()->tell();
     }
@@ -291,7 +291,7 @@ final class ResourceStreamTest extends TestCase
     public function testWriteThrowsIfFwriteFails(): void
     {
         // Test that the method throws if fwrite() fails
-        $this->forcedFailures->fwrite = true;
+        $this->phpOverrides->fwrite = false;
         $this->expectExceptionMessage("Call to fwrite() failed.");
         $this->createReadWriteResourceStream()->write("Hello World!");
     }
@@ -338,7 +338,7 @@ final class ResourceStreamTest extends TestCase
     public function testReadThrowsIfFreadFails(): void
     {
         // Test that the method throws if fread() fails
-        $this->forcedFailures->fread = true;
+        $this->phpOverrides->fread = false;
         $this->expectExceptionMessage("Call to fread() failed.");
         $this->createReadWriteResourceStream()->read(10);
     }
@@ -372,7 +372,7 @@ final class ResourceStreamTest extends TestCase
     public function testGetContentsThrowsIfStreamGetContentsFails(): void
     {
         // Test that the method throws if fread() fails
-        $this->forcedFailures->stream_get_contents = true;
+        $this->phpOverrides->stream_get_contents = false;
         $this->expectExceptionMessage("Call to stream_get_contents() failed.");
         $this->createReadWriteResourceStream()->getContents();
     }
@@ -422,5 +422,5 @@ final class ResourceStreamTest extends TestCase
         return new ResourceStream($resource);
     }
 
-    private ForcedFailures $forcedFailures;
+    private PhpOverrides $phpOverrides;
 }

--- a/test/Http/Stream/ResourceStreamTest.php
+++ b/test/Http/Stream/ResourceStreamTest.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Colossal\Http\Stream\Testing;
+namespace Colossal\Http\Stream;
 
+use Colossal\Http\Stream\ForcedFailures;
 use Colossal\Http\Stream\ResourceStream;
 use PHPUnit\Framework\TestCase;
 
@@ -13,6 +14,12 @@ use PHPUnit\Framework\TestCase;
 final class ResourceStreamTest extends TestCase
 {
     public const ASSERT_INVALID_MESSAGE = "Underlying resource is invalid (has been closed or detached).";
+
+    public function setUp(): void
+    {
+        ForcedFailures::reset();
+        $this->forcedFailures = ForcedFailures::getInstance();
+    }
 
     public function testCreateWithProvidedResourceThrowsForNonResourceArgument(): void
     {
@@ -133,6 +140,14 @@ final class ResourceStreamTest extends TestCase
         $this->assertNull($resourceStream->getSize());
     }
 
+    public function testGetSizeThrowsIfFstatFails(): void
+    {
+        // Test that the method throws if fstat() fails
+        $this->forcedFailures->fstat = true;
+        $this->expectExceptionMessage("Call to fstat() failed.");
+        $this->createReadWriteResourceStream()->getSize();
+    }
+
     public function testTell(): void
     {
         // Test the method for the general use case.
@@ -153,6 +168,14 @@ final class ResourceStreamTest extends TestCase
         $resourceStream->close();
         $this->expectExceptionMessage(self::ASSERT_INVALID_MESSAGE);
         $resourceStream->tell();
+    }
+
+    public function testTellThrowsIfFstatFails(): void
+    {
+        // Test that the method throws if ftell() fails
+        $this->forcedFailures->ftell = true;
+        $this->expectExceptionMessage("Call to ftell() failed.");
+        $this->createReadWriteResourceStream()->tell();
     }
 
     public function testEof(): void
@@ -265,6 +288,14 @@ final class ResourceStreamTest extends TestCase
         $this->createReadOnlyResourceStream()->write("Hello World!");
     }
 
+    public function testWriteThrowsIfFwriteFails(): void
+    {
+        // Test that the method throws if fwrite() fails
+        $this->forcedFailures->fwrite = true;
+        $this->expectExceptionMessage("Call to fwrite() failed.");
+        $this->createReadWriteResourceStream()->write("Hello World!");
+    }
+
     public function testIsReadable(): void
     {
         // Test that the method works for read-only, write-only and read-write resource streams.
@@ -304,6 +335,14 @@ final class ResourceStreamTest extends TestCase
         $this->createWriteOnlyResourceStream()->read(10);
     }
 
+    public function testReadThrowsIfFreadFails(): void
+    {
+        // Test that the method throws if fread() fails
+        $this->forcedFailures->fread = true;
+        $this->expectExceptionMessage("Call to fread() failed.");
+        $this->createReadWriteResourceStream()->read(10);
+    }
+
     public function testGetContents(): void
     {
         // Test the method for the general use case.
@@ -328,6 +367,14 @@ final class ResourceStreamTest extends TestCase
         // Test that the method throws if the underlying stream is not readable.
         $this->expectException(\RuntimeException::class);
         $this->createWriteOnlyResourceStream()->getContents();
+    }
+
+    public function testGetContentsThrowsIfStreamGetContentsFails(): void
+    {
+        // Test that the method throws if fread() fails
+        $this->forcedFailures->stream_get_contents = true;
+        $this->expectExceptionMessage("Call to stream_get_contents() failed.");
+        $this->createReadWriteResourceStream()->getContents();
     }
 
     public function testGetMetadata(): void
@@ -374,4 +421,6 @@ final class ResourceStreamTest extends TestCase
 
         return new ResourceStream($resource);
     }
+
+    private ForcedFailures $forcedFailures;
 }

--- a/test/Http/UploadedFileTest.php
+++ b/test/Http/UploadedFileTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Colossal\Http;
+
+use Colossal\Http\UploadedFile;
+use Colossal\PhpOverrides;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Colossal\Http\UploadedFile
+ * @uses \Colossal\Http\Stream\ResourceStream
+ * @uses \Colossal\Utilities\Rfc3986
+ */
+final class UploadedFileTest extends TestCase
+{
+    public const UPLOADED_FILE_ERROR_EXCEPTION_MESSAGE = "The uploaded file failed with error 'UPLOAD_ERR_INI_SIZE'.";
+    public const UPLOADED_FILE_HAS_MOVED_EXCEPTION_MESSAGE = "The uploaded file has been previously moved.";
+
+    public function setUp(): void
+    {
+        PhpOverrides::reset();
+        $this->phpOverrides = PhpOverrides::getInstance();
+    }
+
+    public function createUploadedFile(string $filePath, int $error): UploadedFile
+    {
+        return new UploadedFile(
+            $filePath,
+            1000,
+            $error,
+            "clientFileName",
+            "clientMediaType"
+        );
+    }
+
+    public function createUploadedFileThatHasMoved(): UploadedFile
+    {
+        $this->phpOverrides->php_sapi_name = "cli";
+        $this->phpOverrides->rename = true;
+
+        $uploadedFile = $this->createUploadedFile("oldFilePath", 0);
+        $uploadedFile->moveTo("newFilePath");
+
+        return $uploadedFile;
+    }
+
+    public function testBasicGetters(): void
+    {
+        // Test the basic getters (mostly to complete coverage)
+        $uploadedFile = new UploadedFile(
+            "filePath",
+            1000,
+            1,
+            "clientFileName",
+            "clientMediaType"
+        );
+        $this->assertEquals(1000, $uploadedFile->getSize());
+        $this->assertEquals(1, $uploadedFile->getError());
+        $this->assertEquals("clientFileName", $uploadedFile->getClientFilename());
+        $this->assertEquals("clientMediaType", $uploadedFile->getClientMediaType());
+    }
+
+    public function testGetStream(): void
+    {
+        $resource = fopen("php://temp", "r");
+        if ($resource === false || !is_resource($resource)) {
+            throw new \RuntimeException("Call to fopen() failed.");
+        }
+        $this->phpOverrides->fopen = $resource;
+
+        // Test that the method works in the general case (lazy initialization works, etc.)
+        $uploadedFile = $this->createUploadedFile("filePath", 0);
+        $this->assertEquals($resource, $uploadedFile->getStream()->detach());
+
+        fclose($resource);
+    }
+
+    public function testGetStreamThrowsIfErrorNotOk(): void
+    {
+        // Test that the method throws if the error of the uploaded file is not ok
+        $this->expectExceptionMessage(self::UPLOADED_FILE_ERROR_EXCEPTION_MESSAGE);
+        $this->createUploadedFile("filePath", 1)->getStream();
+    }
+
+    public function testGetStreamThrowsIfHasMoved(): void
+    {
+        // Test that the method throws if the uploaded file has already been moved
+        $this->expectExceptionMessage(self::UPLOADED_FILE_HAS_MOVED_EXCEPTION_MESSAGE);
+        $this->createUploadedFileThatHasMoved()->getStream();
+    }
+
+    public function testGetStreamThrowsIfFopenFails(): void
+    {
+        $this->phpOverrides->fopen = false;
+
+        // Test that the method fails if the call to fopen() fails
+        $this->expectException(\RuntimeException::class);
+        $this->createUploadedFile("oldFilePath", 0)->getStream();
+    }
+
+    public function testMoveToThrowsIfErrorNotOk(): void
+    {
+        // Test that the method throws if the error of the uploaded file is not ok
+        $this->expectExceptionMessage(self::UPLOADED_FILE_ERROR_EXCEPTION_MESSAGE);
+        $this->createUploadedFile("oldFilePath", 1)->moveTo("newFilePath");
+    }
+
+    public function testMoveToThrowsIfHasMoved(): void
+    {
+        // Test that the method throws if the uploaded file has already been moved
+        $this->expectExceptionMessage(self::UPLOADED_FILE_HAS_MOVED_EXCEPTION_MESSAGE);
+        $this->createUploadedFileThatHasMoved()->moveTo("newFilePath");
+    }
+
+    public function testMoveToThrowsForNonStringTargetPathArgument(): void
+    {
+        // Test that the method throws when we provide it with a non string value for the argument 'targetPath'
+        $this->expectException(\InvalidArgumentException::class);
+        $this->createUploadedFile("oldFilePath", 0)->moveTo(1); /** @phpstan-ignore-line */
+    }
+
+    public function testMoveToThrowsIfTargetPathIsDir(): void
+    {
+        $this->phpOverrides->is_dir = true;
+
+        // Test that the method throws if the target path is a directory
+        $this->expectExceptionMessage("Path 'newFilePath' coincides with existing directory.");
+        $this->createUploadedFile("oldFilePath", 0)->moveTo("newFilePath");
+    }
+
+    public function testMoveToThrowsIfTargetPathIsNonWritable(): void
+    {
+        $this->phpOverrides->is_dir         = false;
+        $this->phpOverrides->is_file        = true;
+        $this->phpOverrides->is_writable    = false;
+
+        // Test that the method throws if the target path is an unwritable file
+        $this->expectExceptionMessage("Path 'newFilePath' coincides with existing unwritable file.");
+        $this->createUploadedFile("oldFilePath", 0)->moveTo("newFilePath");
+    }
+
+    public function testMoveToThrowsIfRenameFailsInNonSapiEnv(): void
+    {
+        $this->phpOverrides->is_dir         = false;
+        $this->phpOverrides->is_file        = false;
+        $this->phpOverrides->php_sapi_name  = "cli";
+        $this->phpOverrides->rename         = false;
+
+        // Test that the method throws if the call to rename() fails
+        $this->expectExceptionMessage("Call to rename() returned false for 'oldFilePath'.");
+        $this->createUploadedFile("oldFilePath", 0)->moveTo("newFilePath");
+    }
+
+    public function testMoveToThrowsIfIsUploadeFileFailsInSapiEnv(): void
+    {
+        $this->phpOverrides->is_dir             = false;
+        $this->phpOverrides->is_file            = false;
+        $this->phpOverrides->php_sapi_name      = "Apache";
+        $this->phpOverrides->is_uploaded_file   = false;
+
+        // Test that the method throws if the call to is_uploaded_file() fails
+        $this->expectExceptionMessage("Call to is_uploaded_file() returned false for 'oldFilePath'.");
+        $this->createUploadedFile("oldFilePath", 0)->moveTo("newFilePath");
+    }
+
+    public function testMoveToThrowsIfMoveUploadedFileFailsInSapiEnv(): void
+    {
+        $this->phpOverrides->is_dir             = false;
+        $this->phpOverrides->is_file            = false;
+        $this->phpOverrides->php_sapi_name      = "Apache";
+        $this->phpOverrides->is_uploaded_file   = true;
+        $this->phpOverrides->move_uploaded_file = false;
+
+        // Test that the method throws if the call to move_uploaded_file() fails
+        $this->expectExceptionMessage("Call to move_uploaded_file() returned false for 'oldFilePath'.");
+        $this->createUploadedFile("oldFilePath", 0)->moveTo("newFilePath");
+    }
+
+    public function testStreamIsClosedWhenMoved(): void
+    {
+        $resource = fopen("php://temp", "r");
+        if ($resource === false || !is_resource($resource)) {
+            throw new \RuntimeException("Call to fopen() failed.");
+        }
+        $this->phpOverrides->fopen              = $resource;
+        $this->phpOverrides->is_dir             = false;
+        $this->phpOverrides->is_file            = false;
+        $this->phpOverrides->php_sapi_name      = "Apache";
+        $this->phpOverrides->is_uploaded_file   = true;
+        $this->phpOverrides->move_uploaded_file = true;
+
+        // Test that the method throws if the call to move_uploaded_file() fails
+        $uploadedFile = $this->createUploadedFile("oldFilePath", 0);
+        $stream = $uploadedFile->getStream();
+        $uploadedFile->moveTo("newFilePath");
+        $this->assertNull($stream->detach());
+    }
+
+    private PhpOverrides $phpOverrides;
+}

--- a/test/Http/UploadedFileTest.php
+++ b/test/Http/UploadedFileTest.php
@@ -191,7 +191,7 @@ final class UploadedFileTest extends TestCase
         $this->phpOverrides->is_uploaded_file   = true;
         $this->phpOverrides->move_uploaded_file = true;
 
-        // Test that the method throws if the call to move_uploaded_file() fails
+        // Test that the underlying stream is closed if the uploaded file is moved
         $uploadedFile = $this->createUploadedFile("oldFilePath", 0);
         $stream = $uploadedFile->getStream();
         $uploadedFile->moveTo("newFilePath");

--- a/test/Http/UriTest.php
+++ b/test/Http/UriTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Colossal\Http\Testing;
+namespace Colossal\Http;
 
 use Colossal\Http\Uri;
 use PHPUnit\Framework\TestCase;

--- a/test/PhpOverrides.php
+++ b/test/PhpOverrides.php
@@ -1,6 +1,6 @@
 <?php
 
-// This file contains classes and functions which allow the forced failure of
+// This file contains classes and functions which allow the overrides of the
 // PHP built in functions. To do so we take advantage of how PHP resolves the
 // symbols.
 //
@@ -11,15 +11,21 @@
 // We declare functions of the same name and signature as the PHP built in
 // functions to do the following based upon flags set in the corresponding
 // singletons:
-//     1. If the flag is set to true, then mock the failure of the function.
-//        (Generally means to return null or false).
+//     1. If the flag is set to true, then mock the return of the function.
 //     2. Otherwise, delegate to the PHP built in function.
+//
+// Keep in mind that while we mock the return of the function, not all of the
+// side effects of the function will occur. For example, populating the $matches
+// array in preg_match. This utility is predominantly useful for forcing the
+// failure of methods that can't be forced to fail under usual circumstances.
 
 declare(strict_types=1);
 
 namespace Colossal
 {
-    class ForcedFailuresBase
+    class NotSet {}
+
+    class PhpOverrides
     {
         protected static null|self $instance = null;
 
@@ -35,29 +41,39 @@ namespace Colossal
         {
             static::$instance = new static();
         }
+
+        public function __construct()
+        {
+            $this->fstat    = new NotSet();
+            $this->ftell    = new NotSet();
+            $this->fwrite   = new NotSet();
+            $this->fread    = new NotSet();
+            $this->stream_get_contents = new NotSet();
+    
+            $this->preg_match = new NotSet();
+            $this->preg_replace_callback = new NotSet();
+        }
+
+        public NotSet|false|array   $fstat;
+        public NotSet|false|int     $ftell;
+        public NotSet|false|int     $fwrite;
+        public NotSet|false|string  $fread;
+        public NotSet|false|string  $stream_get_contents;
+
+        public NotSet|false|int         $preg_match;
+        public NotSet|null|string|array $preg_replace_callback;
     }
 }
 
 namespace Colossal\Http\Stream
 {
-    // phpcs:ignore
-    final class ForcedFailures extends \Colossal\ForcedFailuresBase
-    {
-        public function __construct(
-            public bool $fstat = false,
-            public bool $ftell = false,
-            public bool $fwrite = false,
-            public bool $fread = false,
-            public bool $stream_get_contents = false
-        ) {
-        }
-    }
+    use Colossal\NotSet;
+    use Colossal\PhpOverrides;
 
     function fstat($stream): array|false
     {
-        if (ForcedFailures::getInstance()->fstat) {
-            ForcedFailures::reset();
-            return false;
+        if (!(PhpOverrides::getInstance()->fstat instanceof NotSet)) {
+            return PhpOverrides::getInstance()->fstat;
         } else {
             return \fstat($stream);
         }
@@ -65,9 +81,8 @@ namespace Colossal\Http\Stream
 
     function ftell($stream): int|false
     {
-        if (ForcedFailures::getInstance()->ftell) {
-            ForcedFailures::reset();
-            return false;
+        if (!(PhpOverrides::getInstance()->ftell instanceof NotSet)) {
+            return PhpOverrides::getInstance()->ftell;
         } else {
             return \ftell($stream);
         }
@@ -75,9 +90,8 @@ namespace Colossal\Http\Stream
 
     function fwrite($stream, string $data, ?int $length = null): int|false
     {
-        if (ForcedFailures::getInstance()->fwrite) {
-            ForcedFailures::reset();
-            return false;
+        if (!(PhpOverrides::getInstance()->fwrite instanceof NotSet)) {
+            return PhpOverrides::getInstance()->fwrite;
         } else {
             return \fwrite($stream, $data, $length);
         }
@@ -85,9 +99,8 @@ namespace Colossal\Http\Stream
 
     function fread($stream, int $length): string|false
     {
-        if (ForcedFailures::getInstance()->fread) {
-            ForcedFailures::reset();
-            return false;
+        if (!(PhpOverrides::getInstance()->fread instanceof NotSet)) {
+            return PhpOverrides::getInstance()->fread;
         } else {
             return \fread($stream, $length);
         }
@@ -95,9 +108,8 @@ namespace Colossal\Http\Stream
 
     function stream_get_contents($stream, ?int $length = null, int $offset = -1): string|false
     {
-        if (ForcedFailures::getInstance()->stream_get_contents) {
-            ForcedFailures::reset();
-            return false;
+        if (!(PhpOverrides::getInstance()->stream_get_contents instanceof NotSet)) {
+            return PhpOverrides::getInstance()->stream_get_contents;
         } else {
             return \stream_get_contents($stream, $length, $offset);
         }
@@ -106,30 +118,8 @@ namespace Colossal\Http\Stream
 
 namespace Colossal\Utilities
 {
-    // phpcs:ignore
-    final class ForcedFailuresUtilities
-    {
-        public static null|self $instance = null;
-
-        public static function getInstance(): self
-        {
-            if (is_null(self::$instance)) {
-                self::reset();
-            }
-            return self::$instance;
-        }
-
-        public static function reset(): void
-        {
-            self::$instance = new self();
-        }
-
-        public function __construct(
-            public bool $preg_match = false,
-            public bool $preg_replace_callback = false
-        ) {
-        }
-    }
+    use Colossal\NotSet;
+    use Colossal\PhpOverrides;
 
     function preg_match(
         string $pattern,
@@ -138,9 +128,8 @@ namespace Colossal\Utilities
         int $flags = 0,
         int $offset = 0
     ): int|false {
-        if (ForcedFailuresUtilities::getInstance()->preg_match) {
-            ForcedFailuresUtilities::reset();
-            return false;
+        if (!(PhpOverrides::getInstance()->preg_match instanceof NotSet)) {
+            return PhpOverrides::getInstance()->preg_match;
         } else {
             return \preg_match(
                 $pattern,
@@ -160,9 +149,8 @@ namespace Colossal\Utilities
         int &$count = null,
         int $flags = 0
     ): string|array|null {
-        if (ForcedFailuresUtilities::getInstance()->preg_replace_callback) {
-            ForcedFailuresUtilities::reset();
-            return null;
+        if (!(PhpOverrides::getInstance()->preg_replace_callback instanceof NotSet)) {
+            return PhpOverrides::getInstance()->preg_replace_callback;
         } else {
             return \preg_replace_callback(
                 $pattern,

--- a/test/PhpOverrides.php
+++ b/test/PhpOverrides.php
@@ -1,5 +1,7 @@
 <?php
 
+// phpcs:ignoreFile
+
 // This file contains classes and functions which allow the overrides of the
 // PHP built in functions. To do so we take advantage of how PHP resolves the
 // symbols.
@@ -23,15 +25,17 @@ declare(strict_types=1);
 
 namespace Colossal
 {
-    class NotSet {}
-
-    class PhpOverrides
+    class NotSet
     {
-        protected static null|self $instance = null;
+    }
+
+    final class PhpOverrides
+    {
+        protected static self $instance;
 
         public static function getInstance(): static
         {
-            if (is_null(self::$instance)) {
+            if (!isset(self::$instance)) {
                 static::reset();
             }
             return static::$instance;
@@ -44,24 +48,119 @@ namespace Colossal
 
         public function __construct()
         {
-            $this->fstat    = new NotSet();
-            $this->ftell    = new NotSet();
-            $this->fwrite   = new NotSet();
-            $this->fread    = new NotSet();
+            $this->is_dir = new NotSet();
+            $this->is_file = new NotSet();
+            $this->is_writable = new NotSet();
+            $this->is_uploaded_file = new NotSet();
+            $this->move_uploaded_file = new NotSet();
+            $this->rename = new NotSet();
+            $this->fopen = new NotSet();
+            $this->fstat = new NotSet();
+            $this->ftell = new NotSet();
+            $this->fwrite = new NotSet();
+            $this->fread = new NotSet();
             $this->stream_get_contents = new NotSet();
-    
             $this->preg_match = new NotSet();
             $this->preg_replace_callback = new NotSet();
+            $this->php_sapi_name = new NotSet();
         }
 
-        public NotSet|false|array   $fstat;
-        public NotSet|false|int     $ftell;
-        public NotSet|false|int     $fwrite;
-        public NotSet|false|string  $fread;
-        public NotSet|false|string  $stream_get_contents;
-
-        public NotSet|false|int         $preg_match;
+        public NotSet|bool $is_dir;
+        public NotSet|bool $is_file;
+        public NotSet|bool $is_writable;
+        public NotSet|bool $is_uploaded_file;
+        public NotSet|bool $move_uploaded_file;
+        public NotSet|bool $rename;
+        public mixed $fopen;
+        public NotSet|false|array $fstat;
+        public NotSet|false|int $ftell;
+        public NotSet|false|int $fwrite;
+        public NotSet|false|string $fread;
+        public NotSet|false|string $stream_get_contents;
+        public NotSet|false|int $preg_match;
         public NotSet|null|string|array $preg_replace_callback;
+        public NotSet|false|string $php_sapi_name;
+    }
+}
+
+namespace Colossal\Http
+{
+    use Colossal\NotSet;
+    use Colossal\PhpOverrides;
+
+    function is_dir(string $filename): bool
+    {
+        if (!(PhpOverrides::getInstance()->is_dir instanceof NotSet)) {
+            return PhpOverrides::getInstance()->is_dir;
+        } else {
+            return \is_dir($filename);
+        }
+    }
+
+    function is_file(string $filename): bool
+    {
+        if (!(PhpOverrides::getInstance()->is_file instanceof NotSet)) {
+            return PhpOverrides::getInstance()->is_file;
+        } else {
+            return \is_file($filename);
+        }
+    }
+
+    function is_writable(string $filename): bool
+    {
+        if (!(PhpOverrides::getInstance()->is_writable instanceof NotSet)) {
+            return PhpOverrides::getInstance()->is_writable;
+        } else {
+            return \is_writable($filename);
+        }
+    }
+
+    function is_uploaded_file(string $filename): bool
+    {
+        if (!(PhpOverrides::getInstance()->is_uploaded_file instanceof NotSet)) {
+            return PhpOverrides::getInstance()->is_uploaded_file;
+        } else {
+            return \is_uploaded_file($filename);
+        }
+    }
+
+    function move_uploaded_file(string $from, string $to): bool
+    {
+        if (!(PhpOverrides::getInstance()->move_uploaded_file instanceof NotSet)) {
+            return PhpOverrides::getInstance()->move_uploaded_file;
+        } else {
+            return \move_uploaded_file($from, $to);
+        }
+    }
+
+    function rename(string $from, string $to): bool
+    {
+        if (!(PhpOverrides::getInstance()->rename instanceof NotSet)) {
+            return PhpOverrides::getInstance()->rename;
+        } else {
+            return \rename($from, $to);
+        }
+    }
+
+    function fopen(string $filename, string $mode): mixed
+    {
+        if (
+            !(PhpOverrides::getInstance()->fopen instanceof NotSet) &&
+            (is_bool(PhpOverrides::getInstance()->fopen) || is_resource(PhpOverrides::getInstance()->fopen))
+        ) {
+            return PhpOverrides::getInstance()->fopen;
+        } else {
+            return \fopen($filename, $mode);
+        }
+    }
+
+    function php_sapi_name(): false|string
+    {
+        if (!(PhpOverrides::getInstance()->php_sapi_name instanceof NotSet)) {
+            return PhpOverrides::getInstance()->php_sapi_name;
+        } else {
+            return \php_sapi_name();
+        }
     }
 }
 

--- a/test/Utilities/Rfc3986Test.php
+++ b/test/Utilities/Rfc3986Test.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Colossal\Utilities;
 
-use Colossal\Utilities\ForcedFailuresUtilities;
+use Colossal\PhpOverrides;
 use Colossal\Utilities\Rfc3986;
 use PHPUnit\Framework\TestCase;
 
@@ -15,8 +15,8 @@ final class Rfc3986Test extends TestCase
 {
     public function setUp(): void
     {
-        ForcedFailuresUtilities::reset();
-        $this->forcedFailures = ForcedFailuresUtilities::getInstance();
+        PhpOverrides::reset();
+        $this->phpOverrides = PhpOverrides::getInstance();
     }
 
     public function testParseUriIntoComponents(): void
@@ -63,7 +63,7 @@ final class Rfc3986Test extends TestCase
     public function testParseUriIntoComponentsThrowsIfPregMatchFails(): void
     {
         // Test that the method throws if preg_match() fails
-        $this->forcedFailures->preg_match = true;
+        $this->phpOverrides->preg_match = false;
         $this->expectException(\InvalidArgumentException::class);
         Rfc3986::parseUriIntoComponents("http://localhost:8080");
     }
@@ -386,7 +386,7 @@ final class Rfc3986Test extends TestCase
     public function testEncodeThrowsIfPregReplaceCallbackFails(): void
     {
         // Test that the method throws if preg_replace_callback() fails
-        $this->forcedFailures->preg_replace_callback = true;
+        $this->phpOverrides->preg_replace_callback = null;
         $this->expectException(\RuntimeException::class);
         Rfc3986::encode("http://localhost:8080");
     }
@@ -526,5 +526,5 @@ final class Rfc3986Test extends TestCase
         }
     }
 
-    private ForcedFailuresUtilities $forcedFailures;
+    private PhpOverrides $phpOverrides;
 }

--- a/test/Utilities/Rfc3986Test.php
+++ b/test/Utilities/Rfc3986Test.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Colossal\Utilities\Testing;
+namespace Colossal\Utilities;
 
+use Colossal\Utilities\ForcedFailuresUtilities;
 use Colossal\Utilities\Rfc3986;
 use PHPUnit\Framework\TestCase;
 
@@ -12,6 +13,12 @@ use PHPUnit\Framework\TestCase;
  */
 final class Rfc3986Test extends TestCase
 {
+    public function setUp(): void
+    {
+        ForcedFailuresUtilities::reset();
+        $this->forcedFailures = ForcedFailuresUtilities::getInstance();
+    }
+
     public function testParseUriIntoComponents(): void
     {
         // The following test cases are formatted as follows:
@@ -51,6 +58,14 @@ final class Rfc3986Test extends TestCase
             $this->assertEquals($expectedComponents[3], $components["query"]);
             $this->assertEquals($expectedComponents[4], $components["fragment"]);
         }
+    }
+
+    public function testParseUriIntoComponentsThrowsIfPregMatchFails(): void
+    {
+        // Test that the method throws if preg_match() fails
+        $this->forcedFailures->preg_match = true;
+        $this->expectException(\InvalidArgumentException::class);
+        Rfc3986::parseUriIntoComponents("http://localhost:8080");
     }
 
     public function testIsValidScheme(): void
@@ -368,6 +383,14 @@ final class Rfc3986Test extends TestCase
         $this->assertEquals($expected, Rfc3986::encode($encodedHttpUrl));
     }
 
+    public function testEncodeThrowsIfPregReplaceCallbackFails(): void
+    {
+        // Test that the method throws if preg_replace_callback() fails
+        $this->forcedFailures->preg_replace_callback = true;
+        $this->expectException(\RuntimeException::class);
+        Rfc3986::encode("http://localhost:8080");
+    }
+
     public function testValidateIsAsciiPassingCase(): void
     {
         // Test that the method will not throw when the string contains only US-ASCII
@@ -502,4 +525,6 @@ final class Rfc3986Test extends TestCase
             $this->assertEquals($expected, Rfc3986::isIPvFutureAddress($address), "Test failed for address $address");
         }
     }
+
+    private ForcedFailuresUtilities $forcedFailures;
 }

--- a/test/Utilities/Rfc7230Test.php
+++ b/test/Utilities/Rfc7230Test.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Colossal\Utilities;
 
-use Colossal\Utilities\ForcedFailuresUtilities;
+use Colossal\PhpOverrides;
 use Colossal\Utilities\Rfc7230;
 use PHPUnit\Framework\TestCase;
 
@@ -16,14 +16,8 @@ final class Rfc7230Test extends TestCase
 {
     public function setUp(): void
     {
-        ForcedFailuresUtilities::reset();
-        $this->forcedFailures = ForcedFailuresUtilities::getInstance();
-    }
-
-    public function assertPreConditions(): void
-    {
-        $this->assertFalse($this->forcedFailures->preg_match);
-        $this->assertFalse($this->forcedFailures->preg_replace_callback);
+        PhpOverrides::reset();
+        $this->phpOverrides = PhpOverrides::getInstance();
     }
 
     public function testIsRequestTargetInOriginForm(): void
@@ -70,7 +64,7 @@ final class Rfc7230Test extends TestCase
         $this->assertFalse(Rfc7230::isRequestTargetInAbsoluteForm(""));
 
         // Test when Rfc3986::parseUriInToComponentsFails (preg_match() failing forces this to occur)
-        $this->forcedFailures->preg_match = true;
+        $this->phpOverrides->preg_match = false;
         $this->assertFalse(Rfc7230::isRequestTargetInAbsoluteForm("http://localhost:8000"));
     }
 
@@ -99,5 +93,5 @@ final class Rfc7230Test extends TestCase
         $this->assertTrue(Rfc7230::isRequestTargetInAsteriskForm("*"));
     }
 
-    private ForcedFailuresUtilities $forcedFailures;
+    private PhpOverrides $phpOverrides;
 }

--- a/test/Utilities/Rfc7230Test.php
+++ b/test/Utilities/Rfc7230Test.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Colossal\Utilities\Testing;
+namespace Colossal\Utilities;
 
+use Colossal\Utilities\ForcedFailuresUtilities;
 use Colossal\Utilities\Rfc7230;
 use PHPUnit\Framework\TestCase;
 
@@ -13,6 +14,18 @@ use PHPUnit\Framework\TestCase;
  */
 final class Rfc7230Test extends TestCase
 {
+    public function setUp(): void
+    {
+        ForcedFailuresUtilities::reset();
+        $this->forcedFailures = ForcedFailuresUtilities::getInstance();
+    }
+
+    public function assertPreConditions(): void
+    {
+        $this->assertFalse($this->forcedFailures->preg_match);
+        $this->assertFalse($this->forcedFailures->preg_replace_callback);
+    }
+
     public function testIsRequestTargetInOriginForm(): void
     {
         // Test when the request target contains a valid absolute path and a valid query component
@@ -55,6 +68,10 @@ final class Rfc7230Test extends TestCase
 
         // Test when the request target is empty
         $this->assertFalse(Rfc7230::isRequestTargetInAbsoluteForm(""));
+
+        // Test when Rfc3986::parseUriInToComponentsFails (preg_match() failing forces this to occur)
+        $this->forcedFailures->preg_match = true;
+        $this->assertFalse(Rfc7230::isRequestTargetInAbsoluteForm("http://localhost:8000"));
     }
 
     public function testIsRequestTargetInAuthorityForm(): void
@@ -81,4 +98,6 @@ final class Rfc7230Test extends TestCase
         // Just for the sake of the code coverage metrics really
         $this->assertTrue(Rfc7230::isRequestTargetInAsteriskForm("*"));
     }
+
+    private ForcedFailuresUtilities $forcedFailures;
 }

--- a/test/Utilities/UtilitiesTest.php
+++ b/test/Utilities/UtilitiesTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Colossal\Utilities\Testing;
+namespace Colossal\Utilities;
 
 use Colossal\Utilities\Utilities;
 use PHPUnit\Framework\TestCase;

--- a/test/autoload.php
+++ b/test/autoload.php
@@ -1,0 +1,7 @@
+<?php
+
+// This is required as we MUST load ForcedFailures.php prior to any of the other
+// PHP source files otherwise it seems that the namespace overloads will not work.
+include_once __DIR__ . "/ForcedFailures.php";
+
+include_once __DIR__ . "/../vendor/autoload.php";

--- a/test/autoload.php
+++ b/test/autoload.php
@@ -1,7 +1,7 @@
 <?php
 
-// This is required as we MUST load ForcedFailures.php prior to any of the other
-// PHP source files otherwise it seems that the namespace overloads will not work.
-include_once __DIR__ . "/ForcedFailures.php";
+// This is required as we MUST load PhpOverrides.php prior to any of the other
+// source files otherwise it seems that the namespace overloads will not work.
+include_once __DIR__ . "/PhpOverrides.php";
 
 include_once __DIR__ . "/../vendor/autoload.php";


### PR DESCRIPTION
This pull request creates a class Colossal\Http\UploadedFile that implements the Psr\Http\Message\UploadedFileInterface interface.

The behaviour was implemented as outlined in the comments for the UploadedFileInterface methods.

Associated unit tests have been added as well to verify behaviour.

As the behaviour mostly consists of delegating calls to PHP built in functions, to test these changes a mechanism for overriding the PHP built in functions was devised and used. Some other unit tests were able to benefit from this too so were done as part of this change set. The code coverage on a line-by-line basis is not 100%.