### PR TITLE
Colossalg - Update PHP Code Sniffer rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Run the PHPStan code quality analysis with the following command:
 Run the PHP Code Sniffer code style analysis with the following commands:
 
 ```bash
->> .\vendor\bin\phpcs --standard=PSR12 src
->> .\vendor\bin\phpcs --standard=PSR12 test
+>> .\vendor\bin\phpcs --standard=phpcs.xml src
+>> .\vendor\bin\phpcs --standard=phpcs.xml test
 ```
 
 To fix automatically resolve issues found by PHP Code Sniffer run the following commands:

--- a/README.md
+++ b/README.md
@@ -37,6 +37,6 @@ Run the PHP Code Sniffer code style analysis with the following commands:
 To fix automatically resolve issues found by PHP Code Sniffer run the following commands:
 
 ```bash
->> .\vendor\bin\phpcbf --standard=PSR12 src
->> .\vendor\bin\phpcbf --standard=PSR12 test
+>> .\vendor\bin\phpcbf --standard=phpcs.xml src
+>> .\vendor\bin\phpcbf --standard=phpcs.xml test
 ```

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<ruleset name="Custom">
+    <description>PSR12, but without linelength check, or line endings assertion (this is handled by .gitattributes).</description>
+    <rule ref="PSR12">
+        <exclude name="Generic.Files.LineLength"/>
+        <exclude name="Generic.Files.LineEndings"/>
+    </rule>
+</ruleset>

--- a/test/Http/UploadedFileTest.php
+++ b/test/Http/UploadedFileTest.php
@@ -16,8 +16,8 @@ use PHPUnit\Framework\TestCase;
  */
 final class UploadedFileTest extends TestCase
 {
-    public const UPLOADED_FILE_ERROR_EXCEPTION_MESSAGE = "The uploaded file failed with error 'UPLOAD_ERR_INI_SIZE'.";
-    public const UPLOADED_FILE_HAS_MOVED_EXCEPTION_MESSAGE = "The uploaded file has been previously moved.";
+    public const UPLOADED_FILE_ERROR_EXCEPTION_MESSAGE      = "The uploaded file failed with error 'UPLOAD_ERR_INI_SIZE'.";
+    public const UPLOADED_FILE_HAS_MOVED_EXCEPTION_MESSAGE  = "The uploaded file has been previously moved.";
 
     public function createUploadedFile(string $filePath, int $error): TestableUploadedFile
     {

--- a/test/Http/UriTest.php
+++ b/test/Http/UriTest.php
@@ -289,35 +289,30 @@ final class UriTest extends TestCase
         // detailed in the IUri::__toString() documentation.
         $testCases = [
             // Test each of the individual components on their own (scheme, authority, host, path, query, fragment)
-            "http:"                         => ["http", "", "", "", null, "", "", ""],
-            "http://authority"              => ["http", "", "", "authority", null, "", "", ""],
-            "http:path"                     => ["http", "", "", "", null, "path", "", ""],
-            "http:/path1"                   => ["http", "", "", "", null, "/path1", "", ""],
-            "http:/path2"                   => ["http", "", "", "", null, "//path2", "", ""],
-            "http:?query"                   => ["http", "", "", "", null, "", "query", ""],
-            "http:#fragment"                => ["http", "", "", "", null, "", "", "fragment"],
+            "http:"                                                     => ["http", "", "", "", null, "", "", ""],
+            "http://authority"                                          => ["http", "", "", "authority", null, "", "", ""],
+            "http:path"                                                 => ["http", "", "", "", null, "path", "", ""],
+            "http:/path1"                                               => ["http", "", "", "", null, "/path1", "", ""],
+            "http:/path2"                                               => ["http", "", "", "", null, "//path2", "", ""],
+            "http:?query"                                               => ["http", "", "", "", null, "", "query", ""],
+            "http:#fragment"                                            => ["http", "", "", "", null, "", "", "fragment"],
             // Test some fairly generic looking web URLs
-            "http://localhost:8080"         => ["http", "", "", "localhost", 8080, "", "", ""],
-            "http://localhost:8080/"        => ["http", "", "", "localhost", 8080, "/", "", ""],
-            "http://localhost:8080/index"   => ["http", "", "", "localhost", 8080, "/index", "", ""],
-            "http://localhost:8080/index/"  => ["http", "", "", "localhost", 8080, "/index/", "", ""],
-            "http://localhost:8080/users/1" => ["http", "", "", "localhost", 8080, "/users/1", "", ""],
-            "http://localhost:8080/users?id=1"
-                => ["http", "", "", "localhost", 8080, "users", "id=1", ""],
-            "http://localhost:8080/users?first_name=John&last_name=Doe"
-                => ["http", "", "", "localhost", 8080, "users", "first_name=John&last_name=Doe", ""],
-            "http://localhost:8080/index#title"
-                => ["http", "", "", "localhost", 8080, "index", "", "title"],
-            "http://localhost:8080/users?id=1#profile"
-                => ["http", "", "", "localhost", 8080, "users", "id=1", "profile"],
-            "http://root:password123@localhost:8080/index"
-                => ["http", "root", "password123", "localhost", 8080, "index", "", ""],
-            "http://www.google.com"         => ["http", "", "", "www.google.com", null, "", "", ""],
+            "http://localhost:8080"                                     => ["http", "", "", "localhost", 8080, "", "", ""],
+            "http://localhost:8080/"                                    => ["http", "", "", "localhost", 8080, "/", "", ""],
+            "http://localhost:8080/index"                               => ["http", "", "", "localhost", 8080, "/index", "", ""],
+            "http://localhost:8080/index/"                              => ["http", "", "", "localhost", 8080, "/index/", "", ""],
+            "http://localhost:8080/users/1"                             => ["http", "", "", "localhost", 8080, "/users/1", "", ""],
+            "http://localhost:8080/users?id=1"                          => ["http", "", "", "localhost", 8080, "users", "id=1", ""],
+            "http://localhost:8080/users?first_name=John&last_name=Doe" => ["http", "", "", "localhost", 8080, "users", "first_name=John&last_name=Doe", ""],
+            "http://localhost:8080/index#title"                         => ["http", "", "", "localhost", 8080, "index", "", "title"],
+            "http://localhost:8080/users?id=1#profile"                  => ["http", "", "", "localhost", 8080, "users", "id=1", "profile"],
+            "http://root:password123@localhost:8080/index"              => ["http", "root", "password123", "localhost", 8080, "index", "", ""],
+            "http://www.google.com"                                     => ["http", "", "", "www.google.com", null, "", "", ""],
             // Test the combinations of both authority and path (either on their own are already tested above)
-            "http://authority/path1"        => ["http", "", "", "authority", null, "path1", "", ""],
-            "http://authority/path2"        => ["http", "", "", "authority", null, "/path2", "", ""],
-            "http://authority//path"        => ["http", "", "", "authority", null, "//path", "", ""],
-            "http://authority///path"       => ["http", "", "", "authority", null, "///path", "", ""],
+            "http://authority/path1"                                    => ["http", "", "", "authority", null, "path1", "", ""],
+            "http://authority/path2"                                    => ["http", "", "", "authority", null, "/path2", "", ""],
+            "http://authority//path"                                    => ["http", "", "", "authority", null, "//path", "", ""],
+            "http://authority///path"                                   => ["http", "", "", "authority", null, "///path", "", ""],
         ];
 
         foreach ($testCases as $expected => $components) {

--- a/test/Utilities/Rfc3986Test.php
+++ b/test/Utilities/Rfc3986Test.php
@@ -25,23 +25,20 @@ final class Rfc3986Test extends TestCase
         //          - [4] => The fragment.
         $testCases = [
             // Test each of the individual components on their own (scheme, authority, host, path, query, fragment)
-            "http:"                         => ["http", null, null, null, null],
-            "http://authority"              => ["http", "authority", null, null, null],
-            "http:path"                     => ["http", null, "path", null, null],
-            "http:?query"                   => ["http", null, null, "query", null],
-            "http:#fragment"                => ["http", null, null, null, "fragment"],
+            "http:"                                                             => ["http", null, null, null, null],
+            "http://authority"                                                  => ["http", "authority", null, null, null],
+            "http:path"                                                         => ["http", null, "path", null, null],
+            "http:?query"                                                       => ["http", null, null, "query", null],
+            "http:#fragment"                                                    => ["http", null, null, null, "fragment"],
             // Test some fairly generic looking web URLs
-            "http://localhost:8080"         => ["http", "localhost:8080", null, null, null],
-            "http://localhost:8080/"        => ["http", "localhost:8080", "/", null, null],
-            "http://localhost:8080/users"   => ["http", "localhost:8080", "/users", null, null],
-            "http://localhost:8080/users/"  => ["http", "localhost:8080", "/users/", null, null],
-            "http://localhost:8080/users/1" => ["http", "localhost:8080", "/users/1", null, null],
-            "http://localhost:8080/users?first_name=John&last_name=Doe"
-                => ["http", "localhost:8080", "/users", "first_name=John&last_name=Doe", null],
-            "http://localhost:8080/users?first_name=John&last_name=Doe#profile"
-                => ["http", "localhost:8080", "/users", "first_name=John&last_name=Doe", "profile"],
-            "http://localhost:8080/users#friends"
-                => ["http", "localhost:8080", "/users", null, "friends"]
+            "http://localhost:8080"                                             => ["http", "localhost:8080", null, null, null],
+            "http://localhost:8080/"                                            => ["http", "localhost:8080", "/", null, null],
+            "http://localhost:8080/users"                                       => ["http", "localhost:8080", "/users", null, null],
+            "http://localhost:8080/users/"                                      => ["http", "localhost:8080", "/users/", null, null],
+            "http://localhost:8080/users/1"                                     => ["http", "localhost:8080", "/users/1", null, null],
+            "http://localhost:8080/users?first_name=John&last_name=Doe"         => ["http", "localhost:8080", "/users", "first_name=John&last_name=Doe", null],
+            "http://localhost:8080/users?first_name=John&last_name=Doe#profile" => ["http", "localhost:8080", "/users", "first_name=John&last_name=Doe", "profile"],
+            "http://localhost:8080/users#friends"                               => ["http", "localhost:8080", "/users", null, "friends"]
         ];
 
         foreach ($testCases as $uri => $expectedComponents) {
@@ -113,10 +110,7 @@ final class Rfc3986Test extends TestCase
     public function testEncodeUserInfo(): void
     {
         // Test that the method correctly encodes each character from the unreserved set, sub delims and gen delims
-        $this->assertEquals(
-            "aAzZ09!$&'()*+,;=:%2F%3F%23%5B%5D%40",
-            Rfc3986::encodeUserInfo("aAzZ09!$&'()*+,;=:/?#[]@")
-        );
+        $this->assertEquals("aAzZ09!$&'()*+,;=:%2F%3F%23%5B%5D%40", Rfc3986::encodeUserInfo("aAzZ09!$&'()*+,;=:/?#[]@"));
     }
 
     public function testIsValidHost(): void
@@ -174,7 +168,6 @@ final class Rfc3986Test extends TestCase
         // Test that the method works in some general cases
         $testCases = [
             ""              => true,
-            "%00azAZ09-._~!$&'()*+,;=:@/"   => true,
             "users"         => true,
             "users/"        => true,
             "users/1"       => true,
@@ -185,6 +178,8 @@ final class Rfc3986Test extends TestCase
             "//users/1"     => true,
             "///users/1"    => true,
             "users//1"      => true,
+            // All of the valid characters together
+            "%00azAZ09-._~!$&'()*+,;=:@/"   => true,
             // Invalid characters and percent encodings
             "?"             => false,
             "#"             => false,
@@ -193,7 +188,7 @@ final class Rfc3986Test extends TestCase
             "%A"            => false,
             "%G"            => false,
             "%GA"           => false,
-            "%AG"            => false
+            "%AG"           => false
         ];
 
         foreach ($testCases as $path => $isValid) {
@@ -227,8 +222,9 @@ final class Rfc3986Test extends TestCase
     {
         // Test that the method works in some general cases
         $testCases = [
-            "%00azAZ09-._~!$&'()*+,;=:@/?"  => true,
             "first_name=John&last_name=Doe" => true,
+            // All of the valid characters together
+            "%00azAZ09-._~!$&'()*+,;=:@/?"  => true,
             // Invalid characters and percent encodings
             "#"     => false,
             "["     => false,
@@ -254,8 +250,9 @@ final class Rfc3986Test extends TestCase
     {
         // Test that the method works in some general cases
         $testCases = [
-            "%00azAZ09-._~!$&'()*+,;=:@/?"  => true,
             "index"                         => true,
+            // All of the valid characters together
+            "%00azAZ09-._~!$&'()*+,;=:@/?"  => true,
             // Invalid characters and percent encodings
             "#"     => false,
             "["     => false,


### PR DESCRIPTION
This PR updates the PHP Code Sniffer rules to:

- Allow lines to exceed 120 characters.
- Have any line endings.

Under certain circumstances I don't mind the lines being longer than 120 characters, they still fit easily on my monitor.
This is often the case in unit tests.

For the line endings, I configured .gitattributes early on to do automatic conversion of the line endings to Unix style endings upon commit. The Code Sniffer warnings are just annoying and not really required as the conversion upon checking in to source control is being done automatically anyways via git.

