### PR TITLE
Colossalg - Address issue #14

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -72,20 +72,15 @@ class Request extends Message implements RequestInterface
         if (!is_string($requestTarget)) {
             throw new \InvalidArgumentException("Argument 'requestTarget' must have type string.");
         }
-        if (Rfc7230::IsRequestTargetInOriginForm($requestTarget)) {
-            throw new \InvalidArgumentException(
-                "Argument 'requestTarget' is in origin-form. " .
-                "Must be in absolute-form, authority-form or asterisk-form."
-            );
-        }
         if (
+            !Rfc7230::IsRequestTargetInOriginForm($requestTarget)       &&
             !Rfc7230::IsRequestTargetInAbsoluteForm($requestTarget)     &&
             !Rfc7230::IsRequestTargetInAuthorityForm($requestTarget)    &&
             !Rfc7230::IsRequestTargetInAsteriskForm($requestTarget)
         ) {
             throw new \InvalidArgumentException(
                 "Argument 'requestTarget' is in an unrecognised form. " .
-                "Must be in absolute-form, authority-form or asterisk-form."
+                "Must be in origin-form, absolute-form, authority-form or asterisk-form."
             );
         }
 

--- a/src/HttpFactory/UriFactory.php
+++ b/src/HttpFactory/UriFactory.php
@@ -25,7 +25,7 @@ class UriFactory implements UriFactoryInterface
 
         $scheme     = $components["scheme"];
         $user       = $components["user"];
-        $password   = $components["password"];
+        $pass       = $components["pass"];
         $host       = $components["host"];
         $port       = $components["port"];
         $path       = $components["path"];
@@ -34,7 +34,7 @@ class UriFactory implements UriFactoryInterface
 
         $newUri = new Uri();
         $newUri = is_null($scheme)   ? $newUri : $newUri->withScheme($scheme);
-        $newUri = is_null($user)     ? $newUri : $newUri->withUserInfo($user, $password);
+        $newUri = is_null($user)     ? $newUri : $newUri->withUserInfo($user, $pass);
         $newUri = is_null($host)     ? $newUri : $newUri->withHost($host);
         $newUri = is_null($port)     ? $newUri : $newUri->withPort(intval($port));
         $newUri = is_null($path)     ? $newUri : $newUri->withPath($path);

--- a/test/Http/RequestTest.php
+++ b/test/Http/RequestTest.php
@@ -63,13 +63,6 @@ final class RequestTest extends TestCase
         $this->request->withRequestTarget(1);
     }
 
-    public function testWithRequestTargetThrowsForOriginForm(): void
-    {
-        // Test that the method throws when the string argument 'requestTarget' is in origin form
-        $this->expectException(\InvalidArgumentException::class);
-        $this->request->withRequestTarget("/path?query=abc");
-    }
-
     public function testWithRequestTargetThrowsForUnrecognisedForm(): void
     {
         // Test that the method throws when the string argument 'requestTarget' is in unrecognised form

--- a/test/Utilities/Rfc7230Test.php
+++ b/test/Utilities/Rfc7230Test.php
@@ -22,9 +22,6 @@ final class Rfc7230Test extends TestCase
         $this->assertTrue(Rfc7230::isRequestTargetInOriginForm("/path"));
         $this->assertFalse(Rfc7230::isRequestTargetInOriginForm("/path?"));
 
-        // Test when the request target contains a valid absolute path and an invalid query component
-        $this->assertFalse(Rfc7230::isRequestTargetInOriginForm("/path?query=abc#"));
-
         // Test when the request target contains an invalid absolute path and a valid query component
         $this->assertFalse(Rfc7230::isRequestTargetInOriginForm("path?query=abc"));
         $this->assertFalse(Rfc7230::isRequestTargetInOriginForm("//path?query=abc"));
@@ -32,6 +29,12 @@ final class Rfc7230Test extends TestCase
 
         // Test when the request target is empty
         $this->assertFalse(Rfc7230::isRequestTargetInOriginForm(""));
+
+        // Test when the request target contains a valid absolute path and a valid query component
+        // but the scheme, user, pass, host, port or fragment are present
+        $this->assertFalse(Rfc7230::isRequestTargetInOriginForm("http:path?query=abc"));
+        $this->assertFalse(Rfc7230::isRequestTargetInOriginForm("user:pass123@localhost:8080/path?query=abc"));
+        $this->assertFalse(Rfc7230::isRequestTargetInOriginForm("/path?query=abc#frag"));
     }
 
     public function testIsRequestTargetInAbsoluteForm(): void
@@ -63,17 +66,20 @@ final class Rfc7230Test extends TestCase
         $this->assertTrue(Rfc7230::isRequestTargetInAuthorityForm("localhost:8080"));
 
         // Test when the host is present and correct, and the port is absent
-        $this->assertTrue(Rfc7230::isRequestTargetInAuthorityForm("localhost"));
+        $this->assertFalse(Rfc7230::isRequestTargetInAuthorityForm("localhost"));
 
         // Test when the host is present and correct, and the port is present but incorrect
         $this->assertFalse(Rfc7230::isRequestTargetInAuthorityForm("localhost:[]"));
 
-        // Test when the host is present but incorrect
-        $this->assertFalse(Rfc7230::isRequestTargetInAuthorityForm("[]"));
+        // Test when the host is present but incorrect, and the port is present and correct
         $this->assertFalse(Rfc7230::isRequestTargetInAuthorityForm("[]:8080"));
 
         // Test when the request target is empty
         $this->assertFalse(Rfc7230::isRequestTargetInAuthorityForm(""));
+
+        // Test when the host and port components are present and correct
+        // but the user and pass components are present
+        $this->assertFalse(Rfc7230::isRequestTargetInAuthorityForm("root:password123@localhost:8080"));
     }
 
     public function testIsRequestTargetInAsteriskForm(): void


### PR DESCRIPTION
This PR refactors Rfc3986 and Rfc7230 to address issue #14.

The parsed components of URIs and authorities are now used in the checks for whether request targets are valid.