### PR TITLE
Colossalg - Fix cloning behaviour

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -26,14 +26,6 @@ class Message implements MessageInterface
     }
 
     /**
-     * Copy constructor.
-     */
-    public function __clone()
-    {
-        $this->body = clone $this->body;
-    }
-
-    /**
      * @see MessageInterface::getProtocolVersion()
      */
     public function getProtocolVersion(): string

--- a/src/Request.php
+++ b/src/Request.php
@@ -38,16 +38,6 @@ class Request extends Message implements RequestInterface
     }
 
     /**
-     * Copy constructor.
-     */
-    public function __clone()
-    {
-        parent::__clone();
-
-        $this->uri = clone $this->uri;
-    }
-
-    /**
      * @see RequestInterface::getRequestTarget()
      */
     public function getRequestTarget(): string

--- a/src/Response.php
+++ b/src/Response.php
@@ -65,14 +65,6 @@ class Response extends Message implements ResponseInterface
     }
 
     /**
-     * Copy constructor.
-     */
-    public function __clone()
-    {
-        parent::__clone();
-    }
-
-    /**
      * @see ResponseInterface::getStatusCode()
      */
     public function getStatusCode(): int

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -27,14 +27,6 @@ class ServerRequest extends Request implements ServerRequestInterface
     }
 
     /**
-     * Copy constructor.
-     */
-    public function __clone()
-    {
-        parent::__clone();
-    }
-
-    /**
      * @see ServerRequestInterface::getServerParams()
      */
     public function getServerParams(): array


### PR DESCRIPTION
While using this library I ran in to an issue where calling Message::withBody() would result in an error as the cloning behaviour was incorrect. The Message cloning would clone the underlying Stream representing the body. Both Streams would then hold the same resource, however, and when one was destructed, closing the resource, this would then place the other stream in an invalid state. If that stream then attempted to close it's resource an error would occur.

Cloning streams should not be performed, it does not make sense to have two objects referencing the same resource in an uncoordinated fashion. I had a look and the only other thing cloned in the various cloning methods of the Message hierarchy is the URI. As all the URI methods are implemented in an immutable fashion however it should not matter if two objects share a URI object. As a result it appears all of the cloning methods could just be removed as has been done.